### PR TITLE
issue #33 - s2697, ta 13019: store MD5 checksum on PUT for fs adapter

### DIFF
--- a/cadc-storage-adapter-fs/build.gradle
+++ b/cadc-storage-adapter-fs/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '0.3'
+version = '0.4'
 
 dependencies {
     compile 'log4j:log4j:[1.2,)'

--- a/cadc-storage-adapter-fs/src/main/java/org/opencadc/inventory/storage/fs/FileSystemIterator.java
+++ b/cadc-storage-adapter-fs/src/main/java/org/opencadc/inventory/storage/fs/FileSystemIterator.java
@@ -98,7 +98,6 @@ public class FileSystemIterator implements Iterator<StorageMetadata> {
     private PathItem next = null;
     Stack<StackItem> stack;
     private String fixedParentDir;
-    public static final String CHECKSUM_ATTRIBUTE_NAME = "Artifact.contentChecksum";
 
     /**
      * FileSystemIterator constructor.
@@ -194,7 +193,7 @@ public class FileSystemIterator implements Iterator<StorageMetadata> {
         // TODO: restore bucket consistent with put() return value
         //storageLocation.storageBucket = ??; 
         try {
-            URI checksum = new URI(getFileAttribute(next.path, CHECKSUM_ATTRIBUTE_NAME));
+            URI checksum = new URI(getFileAttribute(next.path, FileSystemStorageAdapter.CHECKSUM_ATTRIBUTE_NAME));
             long length = Files.size(next.path);
             StorageMetadata meta = new StorageMetadata(storageLocation, checksum, length);
             meta.artifactURI = storageID;

--- a/cadc-storage-adapter-fs/src/main/java/org/opencadc/inventory/storage/fs/FileSystemStorageAdapter.java
+++ b/cadc-storage-adapter-fs/src/main/java/org/opencadc/inventory/storage/fs/FileSystemStorageAdapter.java
@@ -140,7 +140,7 @@ public class FileSystemStorageAdapter implements StorageAdapter {
     public static final String CONFIG_PROPERTY_ROOT = "root";
     public static final String CONFIG_PROPERTY_BUCKETMODE = "bucketMode";
     public static final String CONFIG_PROPERTY_BUCKETDEPTH = "bucketLength";
-    public static final String CHECKSUM_ATTRIBUTE_NAME = "Artifact.contentChecksum";
+    static final String CHECKSUM_ATTRIBUTE_NAME = "contentChecksum";
     
     static final String MD5_CHECKSUM_SCHEME = "md5";
     static final int MAX_BUCKET_LENGTH = 5;
@@ -591,16 +591,15 @@ public class FileSystemStorageAdapter implements StorageAdapter {
         return ret;
     }
 
-    public static void setFileAttribute(Path path, String propertyName, String property) throws IOException {
+    public static void setFileAttribute(Path path, String attributeKey, String attributeValue) throws IOException {
         log.debug("setFileAttribute: " + path);
-        UserDefinedFileAttributeView udv = Files.getFileAttributeView(path,
-            UserDefinedFileAttributeView.class, LinkOption.NOFOLLOW_LINKS);
-        log.debug("setAttribute: " + propertyName + " = " + property);
-        log.debug("property bytes: " + property.getBytes(Charset.forName("UTF-8")));
-        if (property != null) {
-            property = property.trim();
-            ByteBuffer buf = ByteBuffer.wrap(property.getBytes(Charset.forName("UTF-8")));
-            udv.write(propertyName, buf);
+        if (attributeValue != null) {
+            UserDefinedFileAttributeView udv = Files.getFileAttributeView(path,
+                UserDefinedFileAttributeView.class, LinkOption.NOFOLLOW_LINKS);
+            attributeValue = attributeValue.trim();
+            log.debug("attribute: " + attributeKey + " = " + attributeValue);
+            ByteBuffer buf = ByteBuffer.wrap(attributeValue.getBytes(Charset.forName("UTF-8")));
+            udv.write(attributeKey, buf);
         } // else: do nothing
     }
 

--- a/cadc-storage-adapter-fs/src/test/java/org/opencadc/inventory/storage/fs/FileSystemStorageAdapterTest.java
+++ b/cadc-storage-adapter-fs/src/test/java/org/opencadc/inventory/storage/fs/FileSystemStorageAdapterTest.java
@@ -111,7 +111,7 @@ public class FileSystemStorageAdapterTest {
     private static final byte[] data = dataString.getBytes();
 
     static {
-        Log4jInit.setLevel("org.opencadc.inventory", Level.DEBUG);
+        Log4jInit.setLevel("org.opencadc.inventory", Level.INFO);
     }
     
     @BeforeClass

--- a/cadc-storage-adapter-fs/src/test/java/org/opencadc/inventory/storage/fs/FileSystemStorageAdapterTest.java
+++ b/cadc-storage-adapter-fs/src/test/java/org/opencadc/inventory/storage/fs/FileSystemStorageAdapterTest.java
@@ -88,7 +88,6 @@ import java.util.List;
 import java.util.Set;
 
 import java.util.SortedSet;
-import static java.util.Spliterators.iterator;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.junit.Assert;
@@ -97,7 +96,6 @@ import org.junit.Test;
 import org.opencadc.inventory.storage.NewArtifact;
 import org.opencadc.inventory.storage.StorageMetadata;
 import org.opencadc.inventory.storage.fs.FileSystemStorageAdapter.BucketMode;
-import static java.util.Spliterators.iterator;
 
 /**
  * @author majorb
@@ -113,7 +111,7 @@ public class FileSystemStorageAdapterTest {
     private static final byte[] data = dataString.getBytes();
 
     static {
-        Log4jInit.setLevel("org.opencadc.inventory", Level.INFO);
+        Log4jInit.setLevel("org.opencadc.inventory", Level.DEBUG);
     }
     
     @BeforeClass
@@ -166,6 +164,7 @@ public class FileSystemStorageAdapterTest {
             FileSystemStorageAdapter fs = new FileSystemStorageAdapter(
                 testDir, bucketMode);
             StorageMetadata storageMetadata = fs.put(newArtifact, source);
+
             Assert.assertEquals("artifactURI",  artifactURI, storageMetadata.artifactURI);
             
             TestOutputStream dest = new TestOutputStream();
@@ -174,6 +173,12 @@ public class FileSystemStorageAdapterTest {
             String resultData = new String(dest.mydata);
             log.info("result data: " + resultData);
             Assert.assertEquals("data", dataString, resultData);
+
+            SortedSet<StorageMetadata> fsList = fs.list(storageMetadata.getStorageLocation().storageBucket);
+
+            StorageMetadata listItem = fsList.first();
+            Assert.assertNotNull(listItem.getContentChecksum());
+            log.info("content checksum found: " + listItem.getContentChecksum());
             
             fs.delete(storageMetadata.getStorageLocation());
             
@@ -201,7 +206,7 @@ public class FileSystemStorageAdapterTest {
     public void testList_URIBucketMode() {
         this.testList(BucketMode.URIBUCKET);
     }
-    
+
     private void testList(BucketMode bucketMode) {
         try {
             


### PR DESCRIPTION
Cleaned up some unused imports as well. Added 'list' to the get-put-delete test to make sure the iterator returns a value in the checksum. More than that can't be done until the iterator is fixed (issue #66 )