### PR TITLE
working SwiftStorageAdapter and other issues addressed

### DIFF
--- a/cadc-inventory-db/src/main/java/org/opencadc/inventory/db/SQLGenerator.java
+++ b/cadc-inventory-db/src/main/java/org/opencadc/inventory/db/SQLGenerator.java
@@ -1076,7 +1076,7 @@ public class SQLGenerator {
             hasRow = rs.next();
             log.debug("ArtifactResultSetIterator: " + super.toString() + " ctor " + hasRow);
             if (!hasRow) {
-                log.warn("ArtifactResultSetIterator:  " + super.toString() + " ctor - setAutoCommit(true)");
+                log.debug("ArtifactResultSetIterator:  " + super.toString() + " ctor - setAutoCommit(true)");
                 con.setAutoCommit(true);
             }
         }

--- a/cadc-inventory/build.gradle
+++ b/cadc-inventory/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '0.7.3'
+version = '0.7.4'
 
 dependencies {
     compile 'log4j:log4j:[1.2,)'

--- a/cadc-inventory/src/main/java/org/opencadc/inventory/Artifact.java
+++ b/cadc-inventory/src/main/java/org/opencadc/inventory/Artifact.java
@@ -139,9 +139,11 @@ public class Artifact extends Entity {
         InventoryUtil.assertNotNull(Artifact.class, "contentChecksum", contentChecksum);
         InventoryUtil.assertNotNull(Artifact.class, "contentLastModified", contentLastModified);
         InventoryUtil.assertNotNull(Artifact.class, "contentLength", contentLength);
+        InventoryUtil.assertValidChecksumURI(Artifact.class, "contentChecksum", contentChecksum);
         if (contentLength <= 0L) {
             throw new IllegalArgumentException("invalid " + Artifact.class.getSimpleName() + ".contentLength: " + contentLength);
         }
+        
         this.uri = uri;
         this.contentChecksum = contentChecksum;
         this.contentLastModified = contentLastModified;

--- a/cadc-inventory/src/main/java/org/opencadc/inventory/InventoryUtil.java
+++ b/cadc-inventory/src/main/java/org/opencadc/inventory/InventoryUtil.java
@@ -232,7 +232,7 @@ public abstract class InventoryUtil {
             assertValidPathComponent(null, "scheme-specific-part", c);
         }
     }
-
+    
     /**
      * Find storage site by unique id.
      *
@@ -292,6 +292,7 @@ public abstract class InventoryUtil {
      * @param u the URI
      */
     public static void assignMetaChecksum(Entity ce, URI u) {
+        assertValidChecksumURI(InventoryUtil.class, "assignMetaChecksum", u);
         try {
             Field f = Entity.class.getDeclaredField("metaChecksum");
             f.setAccessible(true);
@@ -359,17 +360,60 @@ public abstract class InventoryUtil {
      * @throws IllegalArgumentException if the value is invalid
      */
     public static void assertValidChecksumURI(Class caller, String name, URI uri) {
-        String scheme = uri.getScheme();
+        String alg = uri.getScheme();
         String sval = uri.getSchemeSpecificPart();
-        if (scheme == null || sval == null) {
+        if (alg == null || sval == null) {
             throw new IllegalArgumentException("invalid " + caller.getSimpleName() + "." + name + ": "
                 + uri + "reason: expected <algorithm>:<hex value>");
         }
+        byte[] b;
         try {
-            byte[] b = HexUtil.toBytes(sval); // TODO: could check algorithm vs length here
+            b = HexUtil.toBytes(sval);
         } catch (IllegalArgumentException ex) {
-            throw new IllegalArgumentException("invalid " + caller.getSimpleName() + "." + name + ": "
-                + uri + " contains invalid hex chars -- expected <algorithm>:<hex value>");
+            throw new IllegalArgumentException("invalid Artifact.contentChecksum: " 
+                + uri + " contains invalid hex chars, expected <algorithm>:<hex value>");
         }
+        
+        if ("md5".equals(alg)) {
+            if (b.length != 16) {
+                throw new IllegalArgumentException("invalid checksum URI: " + uri 
+                        + " found " + b.length + " bytes, expected 16");
+            }
+            return;
+        }
+        
+        if ("sha-1".equals(alg)) {
+            if (b.length != 20) {
+                throw new IllegalArgumentException("invalid checksum URI: " + uri 
+                        + " found " + b.length + " bytes, expected 20");
+            }
+            return;
+        } 
+        
+        if ("sha-256".equals(alg)) {
+            if (b.length != 32) {
+                throw new IllegalArgumentException("invalid checksum URI: " + uri 
+                        + " found " + b.length + " bytes, expected 32");
+            }
+            return;
+        }
+        
+        if ("sha-384".equals(alg)) {
+            if (b.length != 48) {
+                throw new IllegalArgumentException("invalid checksum URI: " + uri 
+                        + " found " + b.length + " bytes, expected 48");
+            }
+            return;
+        }
+        
+        if ("sha-512".equals(alg)) {
+            if (b.length != 64) {
+                throw new IllegalArgumentException("invalid checksum URI: " + uri 
+                        + " found " + b.length + " bytes, expected 64");
+            }
+            return;
+        }
+        
+        throw new IllegalArgumentException("invalid checksum URI: " + uri + " unsupported algorithm");
     }
 }

--- a/cadc-inventory/src/test/java/org/opencadc/inventory/InventoryUtilTest.java
+++ b/cadc-inventory/src/test/java/org/opencadc/inventory/InventoryUtilTest.java
@@ -67,10 +67,13 @@
 
 package org.opencadc.inventory;
 
+import ca.nrc.cadc.util.HexUtil;
 import ca.nrc.cadc.util.Log4jInit;
 
 import java.net.URI;
+import java.security.MessageDigest;
 import java.util.Comparator;
+import java.util.Random;
 import java.util.UUID;
 
 import org.apache.log4j.Level;
@@ -198,6 +201,101 @@ public class InventoryUtilTest {
                 log.info("caught expected: " + expected);
             }
 
+        } catch (Exception unexpected) {
+            log.error("unexpected exception", unexpected);
+            Assert.fail("unexpected exception: " + unexpected);
+        }
+    }
+    
+    @Test
+    public void testValidateChecksumURI() {
+        try {
+            Random rnd = new Random();
+            byte[] buf = new byte[1024];
+            
+            MessageDigest md = MessageDigest.getInstance("md5");
+            byte[] cs = md.digest(buf);
+            String hex = HexUtil.toHex(cs);
+            
+            URI valid = URI.create("md5:" + hex);
+            InventoryUtil.assertValidChecksumURI(InventoryUtilTest.class, "test", valid);
+            log.info("valid: " + valid);
+            
+            int n = valid.toASCIIString().length() - 2; // drop one byte
+            URI invalid = URI.create(valid.toASCIIString().substring(0, n));
+            try {
+                InventoryUtil.assertValidChecksumURI(InventoryUtilTest.class, "test", invalid);
+            } catch (IllegalArgumentException expected) {
+                log.info("caught expected: " + expected);
+            }
+            
+            md = MessageDigest.getInstance("sha-1");
+            cs = md.digest(buf);
+            hex = HexUtil.toHex(cs);
+            valid = URI.create("sha-1:" + hex);
+            InventoryUtil.assertValidChecksumURI(InventoryUtilTest.class, "test", valid);
+            log.info("valid: " + valid);
+            
+            n = valid.toASCIIString().length() - 2; // drop one byte
+            invalid = URI.create(valid.toASCIIString().substring(0, n));
+            try {
+                InventoryUtil.assertValidChecksumURI(InventoryUtilTest.class, "test", invalid);
+            } catch (IllegalArgumentException expected) {
+                log.info("caught expected: " + expected);
+            }
+            
+            md = MessageDigest.getInstance("sha-256");
+            cs = md.digest(buf);
+            hex = HexUtil.toHex(cs);
+            valid = URI.create("sha-256:" + hex);
+            InventoryUtil.assertValidChecksumURI(InventoryUtilTest.class, "test", valid);
+            log.info("valid: " + valid);
+            
+            n = valid.toASCIIString().length() - 2; // drop one byte
+            invalid = URI.create(valid.toASCIIString().substring(0, n));
+            try {
+                InventoryUtil.assertValidChecksumURI(InventoryUtilTest.class, "test", invalid);
+            } catch (IllegalArgumentException expected) {
+                log.info("caught expected: " + expected);
+            }
+            
+            md = MessageDigest.getInstance("sha-384");
+            cs = md.digest(buf);
+            hex = HexUtil.toHex(cs);
+            valid = URI.create("sha-384:" + hex);
+            InventoryUtil.assertValidChecksumURI(InventoryUtilTest.class, "test", valid);
+            log.info("valid: " + valid);
+            
+            n = valid.toASCIIString().length() - 2; // drop one byte
+            invalid = URI.create(valid.toASCIIString().substring(0, n));
+            try {
+                InventoryUtil.assertValidChecksumURI(InventoryUtilTest.class, "test", invalid);
+            } catch (IllegalArgumentException expected) {
+                log.info("caught expected: " + expected);
+            }
+            
+            md = MessageDigest.getInstance("sha-512");
+            cs = md.digest(buf);
+            hex = HexUtil.toHex(cs);
+            valid = URI.create("sha-512:" + hex);
+            InventoryUtil.assertValidChecksumURI(InventoryUtilTest.class, "test", valid);
+            log.info("valid: " + valid);
+            
+            n = valid.toASCIIString().length() - 2; // drop one byte
+            invalid = URI.create(valid.toASCIIString().substring(0, n));
+            try {
+                InventoryUtil.assertValidChecksumURI(InventoryUtilTest.class, "test", invalid);
+            } catch (IllegalArgumentException expected) {
+                log.info("caught expected: " + expected);
+            }
+            
+            invalid = URI.create("foo:" + hex);
+            try {
+                InventoryUtil.assertValidChecksumURI(InventoryUtilTest.class, "test", invalid);
+            } catch (IllegalArgumentException expected) {
+                log.info("caught expected: " + expected);
+            }
+            
         } catch (Exception unexpected) {
             log.error("unexpected exception", unexpected);
             Assert.fail("unexpected exception: " + unexpected);

--- a/cadc-storage-adapter-ceph/build.gradle
+++ b/cadc-storage-adapter-ceph/build.gradle
@@ -22,7 +22,7 @@ apply from: '../opencadc.gradle'
 dependencies {
     compile 'log4j:log4j:[1.2,)'
     compile 'org.opencadc:cadc-util:[1.2.31,)'
-    compile 'org.opencadc:cadc-storage-adapter:[0.4,)'
+    compile 'org.opencadc:cadc-storage-adapter:[0.6,)'
 
     // Java FITS library.
     compile 'gov.nasa.gsfc.heasarc:nom-tam-fits:[1,2)'
@@ -30,7 +30,14 @@ dependencies {
     // RADOS Java Library from Ceph
     //compile 'com.ceph:rados:0.6.0-SNAPSHOT'
 
-    // Amazon S3 Java Library
+    // swift API
+    //compile 'org.javaswift:joss:0.10.4-pdowler'
+    compile 'org.javaswift:joss:0.10.4'
+
+    runtime 'org.slf4j:slf4j-nop:[1.6,)'
+    //runtime 'org.slf4j:slf4j-log4j12:[1.6,2.0)'
+    
+    // Amazon S3 Java Library -- huge number of what look like server side dependencies
     compile 'software.amazon.awssdk:s3:2.10.49'
 
     testCompile 'junit:junit:[4.0,)'

--- a/cadc-storage-adapter-ceph/src/intTest/java/org/opencadc/inventory/storage/swift/SwiftStorageAdapterTest.java
+++ b/cadc-storage-adapter-ceph/src/intTest/java/org/opencadc/inventory/storage/swift/SwiftStorageAdapterTest.java
@@ -317,13 +317,14 @@ public class SwiftStorageAdapterTest {
     @Test
     public void testIterator() {
         
+        int iterNum = 66;
         try {
             MessageDigest md = MessageDigest.getInstance("MD5");
             Random rnd = new Random();
             byte[] data = new byte[1024];
             
             SortedSet<StorageMetadata> expected = new TreeSet<>();
-            for (int i = 0; i < 10; i++) {
+            for (int i = 0; i < iterNum; i++) {
                 URI artifactURI = URI.create("cadc:TEST/testIterator-" + i);
                 rnd.nextBytes(data);
                 NewArtifact na = new NewArtifact(artifactURI);
@@ -376,13 +377,14 @@ public class SwiftStorageAdapterTest {
     @Test
     public void testIteratorBucketPrefix() {
         
+        int iterNum = 66;
         try {
             MessageDigest md = MessageDigest.getInstance("MD5");
             Random rnd = new Random();
             byte[] data = new byte[1024];
             
             SortedSet<StorageMetadata> expected = new TreeSet<>();
-            for (int i = 0; i < 10; i++) {
+            for (int i = 0; i < iterNum; i++) {
                 URI artifactURI = URI.create("cadc:TEST/testIteratorBucketPrefix-" + i);
                 rnd.nextBytes(data);
                 NewArtifact na = new NewArtifact(artifactURI);

--- a/cadc-storage-adapter-ceph/src/intTest/java/org/opencadc/inventory/storage/swift/SwiftStorageAdapterTest.java
+++ b/cadc-storage-adapter-ceph/src/intTest/java/org/opencadc/inventory/storage/swift/SwiftStorageAdapterTest.java
@@ -1,0 +1,566 @@
+/*
+************************************************************************
+*******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+**************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+*
+*  (c) 2020.                            (c) 2020.
+*  Government of Canada                 Gouvernement du Canada
+*  National Research Council            Conseil national de recherches
+*  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+*  All rights reserved                  Tous droits réservés
+*
+*  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+*  expressed, implied, or               énoncée, implicite ou légale,
+*  statutory, of any kind with          de quelque nature que ce
+*  respect to the software,             soit, concernant le logiciel,
+*  including without limitation         y compris sans restriction
+*  any warranty of merchantability      toute garantie de valeur
+*  or fitness for a particular          marchande ou de pertinence
+*  purpose. NRC shall not be            pour un usage particulier.
+*  liable in any event for any          Le CNRC ne pourra en aucun cas
+*  damages, whether direct or           être tenu responsable de tout
+*  indirect, special or general,        dommage, direct ou indirect,
+*  consequential or incidental,         particulier ou général,
+*  arising from the use of the          accessoire ou fortuit, résultant
+*  software.  Neither the name          de l'utilisation du logiciel. Ni
+*  of the National Research             le nom du Conseil National de
+*  Council of Canada nor the            Recherches du Canada ni les noms
+*  names of its contributors may        de ses  participants ne peuvent
+*  be used to endorse or promote        être utilisés pour approuver ou
+*  products derived from this           promouvoir les produits dérivés
+*  software without specific prior      de ce logiciel sans autorisation
+*  written permission.                  préalable et particulière
+*                                       par écrit.
+*
+*  This file is part of the             Ce fichier fait partie du projet
+*  OpenCADC project.                    OpenCADC.
+*
+*  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+*  you can redistribute it and/or       vous pouvez le redistribuer ou le
+*  modify it under the terms of         modifier suivant les termes de
+*  the GNU Affero General Public        la “GNU Affero General Public
+*  License as published by the          License” telle que publiée
+*  Free Software Foundation,            par la Free Software Foundation
+*  either version 3 of the              : soit la version 3 de cette
+*  License, or (at your option)         licence, soit (à votre gré)
+*  any later version.                   toute version ultérieure.
+*
+*  OpenCADC is distributed in the       OpenCADC est distribué
+*  hope that it will be useful,         dans l’espoir qu’il vous
+*  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+*  without even the implied             GARANTIE : sans même la garantie
+*  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+*  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+*  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+*  General Public License for           Générale Publique GNU Affero
+*  more details.                        pour plus de détails.
+*
+*  You should have received             Vous devriez avoir reçu une
+*  a copy of the GNU Affero             copie de la Licence Générale
+*  General Public License along         Publique GNU Affero avec
+*  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+*  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+*                                       <http://www.gnu.org/licenses/>.
+*
+************************************************************************
+*/
+
+package org.opencadc.inventory.storage.swift;
+
+import ca.nrc.cadc.io.ByteLimitExceededException;
+import ca.nrc.cadc.net.PreconditionFailedException;
+import ca.nrc.cadc.net.ResourceNotFoundException;
+import ca.nrc.cadc.util.HexUtil;
+import ca.nrc.cadc.util.Log4jInit;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.opencadc.inventory.StorageLocation;
+import org.opencadc.inventory.storage.NewArtifact;
+import org.opencadc.inventory.storage.StorageMetadata;
+
+/**
+ *
+ * @author pdowler
+ */
+public class SwiftStorageAdapterTest {
+    private static final Logger log = Logger.getLogger(SwiftStorageAdapterTest.class);
+
+    static {
+        Log4jInit.setLevel("org.opencadc.inventory", Level.INFO);
+        Log4jInit.setLevel("org.javaswift.joss.client", Level.INFO);
+    }
+    
+    final SwiftStorageAdapter adapter;
+    
+    public SwiftStorageAdapterTest() {
+        this.adapter = new SwiftStorageAdapter();
+    }
+    
+    @Before
+    public void cleanup() throws Exception {
+        final long t1 = System.currentTimeMillis();
+        log.info("cleanup: ");
+        Iterator<StorageMetadata> sbi = adapter.iterator();
+        while (sbi.hasNext()) {
+            StorageLocation loc = sbi.next().getStorageLocation();
+            adapter.delete(loc);
+            log.info("\tdeleted: " + loc);
+        }
+    }
+    
+    @Test
+    public void testNoOp() {
+    }
+    
+    @Test
+    public void testResourceNotFound() {
+        try {
+            StorageLocation loc = adapter.generateStorageLocation();
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            adapter.get(loc, bos);
+            Assert.fail("expected ResourceNotFoundException, transferred " + bos.toByteArray().length + " bytes");
+        } catch (ResourceNotFoundException expected) {
+            log.info("caught expected: " + expected);
+        } catch (Exception unexpected) {
+            log.error("unexpected exception", unexpected);
+            Assert.fail("unexpected exception: " + unexpected);
+        }
+    }
+    
+    @Test
+    public void testPutGetDelete() {
+        URI artifactURI = URI.create("cadc:TEST/testPutGetDelete");
+        
+        try {
+            MessageDigest md = MessageDigest.getInstance("MD5");
+            Random rnd = new Random();
+            byte[] data = new byte[1024];
+            rnd.nextBytes(data);
+            
+            NewArtifact na = new NewArtifact(artifactURI);
+            md.update(data);
+            URI expectedChecksum = URI.create("md5:" + HexUtil.toHex(md.digest()));
+            na.contentChecksum = expectedChecksum;
+            na.contentLength = (long) data.length;
+            log.debug("testPutGetDelete random data: " + data.length + " " + expectedChecksum);
+            
+            log.debug("testPutGetDelete put: " + artifactURI);
+            StorageMetadata sm = adapter.put(na, new ByteArrayInputStream(data));
+            log.info("testPutGetDelete put: " + artifactURI + " to " + sm.getStorageLocation());
+            
+            // verify data stored
+            log.debug("testPutGetDelete get: " + artifactURI);
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            adapter.get(sm.getStorageLocation(), bos);
+            md.reset();
+            byte[] actual = bos.toByteArray();
+            md.update(actual);
+            URI actualChecksum = URI.create("md5:" + HexUtil.toHex(md.digest()));
+            log.info("testPutGetDelete get: " + artifactURI + " " + actual.length + " " + actualChecksum);
+            Assert.assertEquals("length", (long) na.contentLength, actual.length);
+            Assert.assertEquals("checksum", na.contentChecksum, actualChecksum);
+
+            log.debug("testPutGetDelete delete: " + sm.getStorageLocation());
+            adapter.delete(sm.getStorageLocation());
+            Assert.assertTrue("deleted", !adapter.exists(sm.getStorageLocation()));
+            log.info("testPutGetDelete deleted: " + sm.getStorageLocation());
+        } catch (Exception ex) {
+            log.error("unexpected exception", ex);
+            Assert.fail("unexpected exception: " + ex);
+        }
+    }   
+    
+    @Test
+    public void testPutGetDeleteMinimal() {
+        URI artifactURI = URI.create("cadc:TEST/testPutGetDeleteMinimal");
+        
+        try {
+            Random rnd = new Random();
+            byte[] data = new byte[1024];
+            rnd.nextBytes(data);
+            
+            final NewArtifact na = new NewArtifact(artifactURI);
+            MessageDigest md = MessageDigest.getInstance("MD5");
+            md.update(data);
+            URI expectedChecksum = URI.create("md5:" + HexUtil.toHex(md.digest()));
+            
+            // test that we can store raw input stream data with no optional metadata
+            
+            log.debug("testPutGetDeleteMinimal random data: " + data.length + " " + expectedChecksum);
+            
+            log.debug("testPutGetDeleteMinimal put: " + artifactURI);
+            StorageMetadata sm = adapter.put(na, new ByteArrayInputStream(data));
+            log.info("testPutGetDeleteMinimal put: " + artifactURI + " to " + sm.getStorageLocation());
+            
+            // verify data stored
+            log.debug("testPutGetDeleteMinimal get: " + artifactURI);
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            adapter.get(sm.getStorageLocation(), bos);
+            byte[] actual = bos.toByteArray();
+            md.update(actual);
+            URI actualChecksum = URI.create("md5:" + HexUtil.toHex(md.digest()));
+            log.info("testPutGetDeleteMinimal get: " + artifactURI + " " + actual.length + " " + actualChecksum);
+            Assert.assertEquals("length", data.length, actual.length);
+            Assert.assertEquals("checksum", expectedChecksum, actualChecksum);
+            
+            // TODO: verify metadata captured without using iterator
+            
+            log.debug("testPutGetDeleteMinimal delete: " + sm.getStorageLocation());
+            adapter.delete(sm.getStorageLocation());
+            Assert.assertTrue("deleted", !adapter.exists(sm.getStorageLocation()));
+            log.info("testPutGetDeleteMinimal deleted: " + sm.getStorageLocation());
+        } catch (Exception ex) {
+            log.error("unexpected exception", ex);
+            Assert.fail("unexpected exception: " + ex);
+        }
+    }
+    
+    @Test
+    public void testPutGetDeleteWrongMD5() {
+        URI artifactURI = URI.create("cadc:TEST/testPutGetDeleteWrongMD5");
+        
+        try {
+            Random rnd = new Random();
+            byte[] data = new byte[1024];
+            rnd.nextBytes(data);
+            
+            NewArtifact na = new NewArtifact(artifactURI);
+            na.contentChecksum = URI.create("md5:d41d8cd98f00b204e9800998ecf8427e"); // md5 of 0-length file
+            na.contentLength = (long) data.length;
+            log.debug("testPutGetDeleteWrongMD5 random data: " + data.length + " " +  na.contentChecksum);
+            
+            try {
+                log.debug("testPutGetDeleteWrongMD5 put: " + artifactURI);
+                StorageMetadata sm = adapter.put(na, new ByteArrayInputStream(data));
+                Assert.fail("expected PreconditionFailedException, got: " + sm.getStorageLocation());
+            } catch (PreconditionFailedException expected) {
+                log.info("testPutGetDeleteWrongMD5 caught: " + expected);
+            }
+            
+        } catch (Exception ex) {
+            log.error("unexpected exception", ex);
+            Assert.fail("unexpected exception: " + ex);
+        }
+    }
+
+    @Test
+    public void testPutLargeStreamReject() {
+        URI artifactURI = URI.create("cadc:TEST/testPutCheckDeleteLargeStreamReject");
+        
+        final NewArtifact na = new NewArtifact(artifactURI);
+        
+        // ceph/S3 limit of 5GiB
+        long numBytes = (long) 6 * 1024 * 1024 * 1024; 
+        na.contentLength = numBytes;
+            
+        try {
+            InputStream istream = getFailer();
+            log.info("testPutCheckDeleteLargeStreamReject put: " + artifactURI + " " + numBytes);
+            StorageMetadata sm = adapter.put(na, istream);
+            Assert.fail("expected ByteLimitExceededException, got: " + sm);
+        } catch (ByteLimitExceededException expected) {
+            log.info("caught: " + expected);
+        } catch (Exception ex) {
+            log.error("unexpected exception", ex);
+            Assert.fail("unexpected exception: " + ex);
+        }
+    }
+    
+    @Test
+    public void testPutLargeStreamFail() {
+        URI artifactURI = URI.create("cadc:TEST/testPutCheckDeleteLargeDataMinimal");
+        
+        final NewArtifact na = new NewArtifact(artifactURI);
+        
+        // ceph/S3 limit of 5GiB
+        long numBytes = (long) 6 * 1024 * 1024 * 1024; 
+            
+        try {
+            InputStream istream = getJunk(numBytes);
+            log.info("testPutCheckDeleteLargeStreamFail put: " + artifactURI + " " + numBytes);
+            StorageMetadata sm = adapter.put(na, istream);
+            log.info("testPutCheckDeleteLargeStreamFail put: " + artifactURI + " to " + sm.getStorageLocation());
+            
+            // TODO: verify metadata captured without using iterator
+
+            log.debug("testPutCheckDeleteLargeStreamFail delete: " + sm.getStorageLocation());
+            adapter.delete(sm.getStorageLocation());
+            Assert.assertTrue("deleted", !adapter.exists(sm.getStorageLocation()));
+            log.info("testPutCheckDeleteLargeStreamFail deleted: " + sm.getStorageLocation());
+            
+            Assert.fail("expected ByteLimitExceededException, got: " + sm);
+        } catch (ByteLimitExceededException expected) {
+            log.info("caught: " + expected);
+        } catch (Exception ex) {
+            log.error("unexpected exception", ex);
+            Assert.fail("unexpected exception: " + ex);
+        }
+    }
+    
+    @Test
+    public void testIterator() {
+        
+        try {
+            MessageDigest md = MessageDigest.getInstance("MD5");
+            Random rnd = new Random();
+            byte[] data = new byte[1024];
+            
+            SortedSet<StorageMetadata> expected = new TreeSet<>();
+            for (int i = 0; i < 10; i++) {
+                URI artifactURI = URI.create("cadc:TEST/testIterator-" + i);
+                rnd.nextBytes(data);
+                NewArtifact na = new NewArtifact(artifactURI);
+                md.update(data);
+                // contentChecksum currently required for round-trip
+                na.contentChecksum = URI.create("md5:" + HexUtil.toHex(md.digest()));
+                na.contentLength = (long) data.length;
+                StorageMetadata sm = adapter.put(na, new ByteArrayInputStream(data));
+                Assert.assertNotNull(sm.artifactURI);
+                //Assert.assertNotNull(sm.contentLastModified);
+                log.debug("testIterator put: " + artifactURI + " to " + sm.getStorageLocation());
+                expected.add(sm);
+            }
+            log.info("testIterator created: " + expected.size());
+            
+            // full iterator
+            List<StorageMetadata> actual = new ArrayList<>();
+            Iterator<StorageMetadata> iter = adapter.iterator();
+            while (iter.hasNext()) {
+                StorageMetadata sm = iter.next();
+                log.debug("found: " + sm.getStorageLocation() + " " + sm.getContentLength() + " " + sm.getContentChecksum());
+                actual.add(sm);
+            }
+            
+            Assert.assertEquals("iterator.size", expected.size(), actual.size());
+            Iterator<StorageMetadata> ei = expected.iterator();
+            Iterator<StorageMetadata> ai = actual.iterator();
+            while (ei.hasNext()) {
+                StorageMetadata em = ei.next();
+                StorageMetadata am = ai.next();
+                log.debug("compare: " + em.getStorageLocation() + " vs " + am.getStorageLocation());
+                Assert.assertEquals("order", em, am);
+                Assert.assertEquals("length", em.getContentLength(), am.getContentLength());
+                Assert.assertEquals("checksum", em.getContentChecksum(), am.getContentChecksum());
+                
+                Assert.assertNotNull("artifactUIRI", am.artifactURI);
+                Assert.assertEquals("artifactURI", em.artifactURI, am.artifactURI);
+                
+                Assert.assertNotNull("contentLastModified", am.contentLastModified);
+                //Assert.assertEquals("contentLastModified", em.contentLastModified, am.contentLastModified);
+            }
+            
+            // rely on cleanup()
+        } catch (Exception ex) {
+            log.error("unexpected exception", ex);
+            Assert.fail("unexpected exception: " + ex);
+        }
+    }
+    
+    @Test
+    public void testIteratorBucketPrefix() {
+        
+        try {
+            MessageDigest md = MessageDigest.getInstance("MD5");
+            Random rnd = new Random();
+            byte[] data = new byte[1024];
+            
+            SortedSet<StorageMetadata> expected = new TreeSet<>();
+            for (int i = 0; i < 10; i++) {
+                URI artifactURI = URI.create("cadc:TEST/testIteratorBucketPrefix-" + i);
+                rnd.nextBytes(data);
+                NewArtifact na = new NewArtifact(artifactURI);
+                md.update(data);
+                na.contentChecksum = URI.create("md5:" + HexUtil.toHex(md.digest()));
+                na.contentLength = (long) data.length;
+                StorageMetadata sm = adapter.put(na, new ByteArrayInputStream(data));
+                log.debug("testList put: " + artifactURI + " to " + sm.getStorageLocation());
+                expected.add(sm);
+            }
+            log.info("testIteratorBucketPrefix created: " + expected.size());
+            
+            int found = 0;
+            for (byte b = 0; b < 16; b++) {
+                String bpre = HexUtil.toHex(b).substring(1);
+                log.debug("bucket prefix: " + bpre);
+                Iterator<StorageMetadata> i = adapter.iterator(bpre);
+                while (i.hasNext()) {
+                    StorageMetadata sm = i.next();
+                    Assert.assertTrue("prefix match", sm.getStorageLocation().storageBucket.startsWith(bpre));
+                    found++;
+                }
+            }
+            Assert.assertEquals("found with bucketPrefix", expected.size(), found);
+            
+        } catch (Exception ex) {
+            log.error("unexpected exception", ex);
+            Assert.fail("unexpected exception: " + ex);
+        }
+    }
+    
+    @Test
+    public void testList() {
+        
+        try {
+            MessageDigest md = MessageDigest.getInstance("MD5");
+            Random rnd = new Random();
+            byte[] data = new byte[1024];
+            
+            SortedSet<StorageMetadata> expected = new TreeSet<>();
+            for (int i = 0; i < 10; i++) {
+                URI artifactURI = URI.create("cadc:TEST/testList-" + i);
+                rnd.nextBytes(data);
+                NewArtifact na = new NewArtifact(artifactURI);
+                md.update(data);
+                na.contentChecksum = URI.create("md5:" + HexUtil.toHex(md.digest()));
+                na.contentLength = (long) data.length;
+                StorageMetadata sm = adapter.put(na, new ByteArrayInputStream(data));
+                log.debug("testList put: " + artifactURI + " to " + sm.getStorageLocation());
+                expected.add(sm);
+            }
+            log.info("testList created: " + expected.size());
+            
+            Set<StorageMetadata> actual = adapter.list(null);
+            
+            Assert.assertEquals("list.size", expected.size(), actual.size());
+            Iterator<StorageMetadata> ei = expected.iterator();
+            Iterator<StorageMetadata> ai = actual.iterator();
+            while (ei.hasNext()) {
+                StorageMetadata em = ei.next();
+                StorageMetadata am = ai.next();
+                log.debug("compare: " + em.getStorageLocation() + " vs " + am.getStorageLocation());
+                Assert.assertEquals("order", em, am);
+                Assert.assertEquals("length", em.getContentLength(), am.getContentLength());
+                Assert.assertEquals("checksum", em.getContentChecksum(), am.getContentChecksum());
+            }
+            
+        } catch (Exception ex) {
+            log.error("unexpected exception", ex);
+            Assert.fail("unexpected exception: " + ex);
+        }
+    }
+    
+    @Test
+    public void testListBucketPrefix() {
+        
+        try {
+            MessageDigest md = MessageDigest.getInstance("MD5");
+            Random rnd = new Random();
+            byte[] data = new byte[1024];
+            
+            SortedSet<StorageMetadata> expected = new TreeSet<>();
+            for (int i = 0; i < 10; i++) {
+                URI artifactURI = URI.create("cadc:TEST/testListBucketPrefix-" + i);
+                rnd.nextBytes(data);
+                NewArtifact na = new NewArtifact(artifactURI);
+                md.update(data);
+                na.contentChecksum = URI.create("md5:" + HexUtil.toHex(md.digest()));
+                na.contentLength = (long) data.length;
+                StorageMetadata sm = adapter.put(na, new ByteArrayInputStream(data));
+                log.debug("testList put: " + artifactURI + " to " + sm.getStorageLocation());
+                expected.add(sm);
+            }
+            log.info("testListBucketPrefix created: " + expected.size());
+            
+            int found = 0;
+            for (byte b = 0; b < 16; b++) {
+                String bpre = HexUtil.toHex(b).substring(1);
+                log.info("bucket prefix: " + bpre);
+                Set<StorageMetadata> bset = adapter.list(bpre);
+                Iterator<StorageMetadata> i = bset.iterator();
+                while (i.hasNext()) {
+                    StorageMetadata sm = i.next();
+                    Assert.assertTrue("prefix match", sm.getStorageLocation().storageBucket.startsWith(bpre));
+                    found++;
+                }
+            }
+            Assert.assertEquals("found with bucketPrefix", expected.size(), found);
+            
+        } catch (Exception ex) {
+            log.error("unexpected exception", ex);
+            Assert.fail("unexpected exception: " + ex);
+        }
+    }
+    
+    
+    private InputStream getJunk(long numBytes) {
+        
+        Random rnd = new Random();
+        byte val = (byte) rnd.nextInt(127);
+        
+        
+        return new InputStream() {
+            long tot = 0L;
+            long ncalls = 0L;
+            
+            @Override
+            public int read() throws IOException {
+                throw new UnsupportedOperationException();
+            }
+            
+            @Override
+            public int read(byte[] bytes) throws IOException {
+                int ret = super.read(bytes, 0, bytes.length);
+                return ret;
+            }
+
+            @Override
+            public int read(byte[] bytes, int off, int len) throws IOException {
+                if (len == 0) {
+                    return 0;
+                }
+                
+                if (tot >= numBytes) {
+                    return -1;
+                }
+                long rem = numBytes - tot;
+                long ret = Math.min(len, rem);
+                Arrays.fill(bytes, val);
+                tot += ret;
+                ncalls++;
+                if ((ncalls % 10000) == 0) {
+                    long mib = tot / (1024L * 1024L);
+                    log.info("output: " + mib + " MiB");
+                }
+                return (int) ret;
+            }
+        };
+    }
+    
+    private InputStream getFailer() {
+        return new InputStream() {
+            
+            @Override
+            public int read() throws IOException {
+                throw new RuntimeException("BUG: stream should not be read");
+            }
+            
+            @Override
+            public int read(byte[] bytes) throws IOException {
+                int ret = super.read(bytes, 0, bytes.length);
+                return ret;
+            }
+
+            @Override
+            public int read(byte[] bytes, int off, int len) throws IOException {
+                throw new RuntimeException("BUG: stream should not be read");
+            }
+        };
+    }
+}

--- a/cadc-storage-adapter-ceph/src/main/java/org/opencadc/inventory/storage/swift/AccessProviderImpl.java
+++ b/cadc-storage-adapter-ceph/src/main/java/org/opencadc/inventory/storage/swift/AccessProviderImpl.java
@@ -1,0 +1,164 @@
+/*
+************************************************************************
+*******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+**************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+*
+*  (c) 2020.                            (c) 2020.
+*  Government of Canada                 Gouvernement du Canada
+*  National Research Council            Conseil national de recherches
+*  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+*  All rights reserved                  Tous droits réservés
+*
+*  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+*  expressed, implied, or               énoncée, implicite ou légale,
+*  statutory, of any kind with          de quelque nature que ce
+*  respect to the software,             soit, concernant le logiciel,
+*  including without limitation         y compris sans restriction
+*  any warranty of merchantability      toute garantie de valeur
+*  or fitness for a particular          marchande ou de pertinence
+*  purpose. NRC shall not be            pour un usage particulier.
+*  liable in any event for any          Le CNRC ne pourra en aucun cas
+*  damages, whether direct or           être tenu responsable de tout
+*  indirect, special or general,        dommage, direct ou indirect,
+*  consequential or incidental,         particulier ou général,
+*  arising from the use of the          accessoire ou fortuit, résultant
+*  software.  Neither the name          de l'utilisation du logiciel. Ni
+*  of the National Research             le nom du Conseil National de
+*  Council of Canada nor the            Recherches du Canada ni les noms
+*  names of its contributors may        de ses  participants ne peuvent
+*  be used to endorse or promote        être utilisés pour approuver ou
+*  products derived from this           promouvoir les produits dérivés
+*  software without specific prior      de ce logiciel sans autorisation
+*  written permission.                  préalable et particulière
+*                                       par écrit.
+*
+*  This file is part of the             Ce fichier fait partie du projet
+*  OpenCADC project.                    OpenCADC.
+*
+*  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+*  you can redistribute it and/or       vous pouvez le redistribuer ou le
+*  modify it under the terms of         modifier suivant les termes de
+*  the GNU Affero General Public        la “GNU Affero General Public
+*  License as published by the          License” telle que publiée
+*  Free Software Foundation,            par la Free Software Foundation
+*  either version 3 of the              : soit la version 3 de cette
+*  License, or (at your option)         licence, soit (à votre gré)
+*  any later version.                   toute version ultérieure.
+*
+*  OpenCADC is distributed in the       OpenCADC est distribué
+*  hope that it will be useful,         dans l’espoir qu’il vous
+*  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+*  without even the implied             GARANTIE : sans même la garantie
+*  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+*  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+*  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+*  General Public License for           Générale Publique GNU Affero
+*  more details.                        pour plus de détails.
+*
+*  You should have received             Vous devriez avoir reçu une
+*  a copy of the GNU Affero             copie de la Licence Générale
+*  General Public License along         Publique GNU Affero avec
+*  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+*  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+*                                       <http://www.gnu.org/licenses/>.
+*
+************************************************************************
+*/
+
+package org.opencadc.inventory.storage.swift;
+
+import ca.nrc.cadc.net.HttpGet;
+import java.io.ByteArrayOutputStream;
+import java.net.URL;
+import org.apache.log4j.Logger;
+import org.javaswift.joss.client.factory.AuthenticationMethod;
+import org.javaswift.joss.client.factory.TempUrlHashPrefixSource;
+import org.javaswift.joss.model.Access;
+
+/**
+ * Implementation of a javaswift AccessProvider for AuthenticationMethod.EXTERNAL mode.
+ * This is not used but retained in case someone wants to know how Swift Auth v1 works,
+ * as a starting point to authenticate vs some API not supported by javaswift,
+ * and/or needs to work around some sort of auth issue as it currently one does.
+ * 
+ * @author pdowler
+ */
+public class AccessProviderImpl implements AuthenticationMethod.AccessProvider {
+    private static final Logger log = Logger.getLogger(AccessProviderImpl.class);
+
+    private final URL authURL;
+    private final String user;
+    private final String  key;
+    
+    public AccessProviderImpl(URL authURL, String user, String key) { 
+        this.authURL = authURL;
+        this.user = user;
+        this.key = key;
+    }
+
+    @Override
+    public Access authenticate() {
+        log.debug("AccessProvider.authenticate - START");
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        HttpGet login = new HttpGet(authURL, bos);
+        login.setFollowRedirects(true);
+        login.setRequestProperty("X-Auth-User", user);
+        login.setRequestProperty("X-Auth-Key", key);
+        login.run();
+        log.debug("auth: " + login.getResponseCode() + " " + login.getContentType());
+        if (login.getThrowable() != null) {
+            throw new RuntimeException("auth failure", login.getThrowable());
+        }
+        String storageURL = login.getResponseHeader("X-Storage-Url");
+        //String storageToken = login.getResponseHeader("X-Storage-Token");
+        String authToken = login.getResponseHeader("X-Auth-Token");
+        log.debug("storageURL: " + storageURL);
+        //log.debug("storageToken: " + storageToken);
+        log.debug("authToken: " + authToken);
+        log.debug("body: " + bos.toString());
+
+        AccessWorkaroundHack ret = new AccessWorkaroundHack();
+        ret.storageURL = storageURL.replace("http://", "https://").replace(":8080", "");
+        ret.token = authToken;
+
+        log.debug("AccessProvider.authenticate - DONE");
+        return ret;
+    }
+    
+    private static class AccessWorkaroundHack implements Access {
+
+        private String token;
+        private String storageURL;
+        
+        @Override
+        public void setPreferredRegion(String string) {
+            //ignore
+        }
+
+        @Override
+        public String getToken() {
+            return token;
+        }
+
+        @Override
+        public String getInternalURL() {
+            return null;
+        }
+
+        @Override
+        public String getPublicURL() {
+            return storageURL;
+        }
+
+        @Override
+        public boolean isTenantSupplied() {
+            return true; // via {username}:{tenant}
+        }
+
+        @Override
+        public String getTempUrlPrefix(TempUrlHashPrefixSource tuhps) {
+            return null;
+        }
+        
+    }
+}

--- a/cadc-storage-adapter-ceph/src/main/java/org/opencadc/inventory/storage/swift/SwiftStorageAdapter.java
+++ b/cadc-storage-adapter-ceph/src/main/java/org/opencadc/inventory/storage/swift/SwiftStorageAdapter.java
@@ -1,0 +1,686 @@
+/*
+************************************************************************
+*******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+**************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+*
+*  (c) 2020.                            (c) 2020.
+*  Government of Canada                 Gouvernement du Canada
+*  National Research Council            Conseil national de recherches
+*  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+*  All rights reserved                  Tous droits réservés
+*
+*  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+*  expressed, implied, or               énoncée, implicite ou légale,
+*  statutory, of any kind with          de quelque nature que ce
+*  respect to the software,             soit, concernant le logiciel,
+*  including without limitation         y compris sans restriction
+*  any warranty of merchantability      toute garantie de valeur
+*  or fitness for a particular          marchande ou de pertinence
+*  purpose. NRC shall not be            pour un usage particulier.
+*  liable in any event for any          Le CNRC ne pourra en aucun cas
+*  damages, whether direct or           être tenu responsable de tout
+*  indirect, special or general,        dommage, direct ou indirect,
+*  consequential or incidental,         particulier ou général,
+*  arising from the use of the          accessoire ou fortuit, résultant
+*  software.  Neither the name          de l'utilisation du logiciel. Ni
+*  of the National Research             le nom du Conseil National de
+*  Council of Canada nor the            Recherches du Canada ni les noms
+*  names of its contributors may        de ses  participants ne peuvent
+*  be used to endorse or promote        être utilisés pour approuver ou
+*  products derived from this           promouvoir les produits dérivés
+*  software without specific prior      de ce logiciel sans autorisation
+*  written permission.                  préalable et particulière
+*                                       par écrit.
+*
+*  This file is part of the             Ce fichier fait partie du projet
+*  OpenCADC project.                    OpenCADC.
+*
+*  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+*  you can redistribute it and/or       vous pouvez le redistribuer ou le
+*  modify it under the terms of         modifier suivant les termes de
+*  the GNU Affero General Public        la “GNU Affero General Public
+*  License as published by the          License” telle que publiée
+*  Free Software Foundation,            par la Free Software Foundation
+*  either version 3 of the              : soit la version 3 de cette
+*  License, or (at your option)         licence, soit (à votre gré)
+*  any later version.                   toute version ultérieure.
+*
+*  OpenCADC is distributed in the       OpenCADC est distribué
+*  hope that it will be useful,         dans l’espoir qu’il vous
+*  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+*  without even the implied             GARANTIE : sans même la garantie
+*  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+*  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+*  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+*  General Public License for           Générale Publique GNU Affero
+*  more details.                        pour plus de détails.
+*
+*  You should have received             Vous devriez avoir reçu une
+*  a copy of the GNU Affero             copie de la Licence Générale
+*  General Public License along         Publique GNU Affero avec
+*  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+*  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+*                                       <http://www.gnu.org/licenses/>.
+*
+************************************************************************
+*/
+
+package org.opencadc.inventory.storage.swift;
+
+import ca.nrc.cadc.io.ByteCountInputStream;
+import ca.nrc.cadc.io.ByteLimitExceededException;
+import ca.nrc.cadc.io.ReadException;
+import ca.nrc.cadc.io.ThreadedIO;
+import ca.nrc.cadc.io.WriteException;
+import ca.nrc.cadc.net.HttpGet;
+import ca.nrc.cadc.net.IncorrectContentChecksumException;
+import ca.nrc.cadc.net.IncorrectContentLengthException;
+import ca.nrc.cadc.net.PreconditionFailedException;
+import ca.nrc.cadc.net.ResourceAlreadyExistsException;
+import ca.nrc.cadc.net.ResourceNotFoundException;
+import ca.nrc.cadc.net.TransientException;
+import ca.nrc.cadc.util.HexUtil;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.SocketException;
+import java.net.URI;
+import java.net.URL;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Properties;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.UUID;
+import org.apache.log4j.Logger;
+import org.javaswift.joss.client.factory.AccountConfig;
+import org.javaswift.joss.client.factory.AccountFactory;
+import org.javaswift.joss.client.factory.AuthenticationMethod;
+import org.javaswift.joss.client.factory.AuthenticationMethod.AccessProvider;
+import org.javaswift.joss.client.factory.TempUrlHashPrefixSource;
+import org.javaswift.joss.exception.CommandException;
+import org.javaswift.joss.exception.Md5ChecksumException;
+import org.javaswift.joss.instructions.UploadInstructions;
+import org.javaswift.joss.model.Access;
+import org.javaswift.joss.model.Account;
+import org.javaswift.joss.model.Container;
+import org.javaswift.joss.model.DirectoryOrObject;
+import org.javaswift.joss.model.StoredObject;
+import org.opencadc.inventory.InventoryUtil;
+import org.opencadc.inventory.StorageLocation;
+import org.opencadc.inventory.storage.NewArtifact;
+import org.opencadc.inventory.storage.StorageAdapter;
+import org.opencadc.inventory.storage.StorageEngageException;
+import org.opencadc.inventory.storage.StorageMetadata;
+
+/**
+ *
+ * @author pdowler
+ */
+public class SwiftStorageAdapter  implements StorageAdapter {
+    private static final Logger log = Logger.getLogger(SwiftStorageAdapter.class);
+
+    private static final long CEPH_UPLOAD_LIMIT = 5 * 1024L * 1024L * 1024L; // 5 GiB
+    private static final String CEPH_UPLOAD_LIMIT_MSG = "5 GiB";
+    
+    private static final String CONFIG_FILENAME = "cadc-storage-adapter-ceph.properties";
+    
+    private static final String CONF_ENDPOINT = SwiftStorageAdapter.class.getName() + ".authEndpoint";
+    private static final String CONF_USER = SwiftStorageAdapter.class.getName() + ".username";
+    private static final String CONF_KEY = SwiftStorageAdapter.class.getName() + ".key";
+    private static final String CONF_SBLEN = SwiftStorageAdapter.class.getName() + ".bucketLength";
+    private static final String CONF_BUCKET = SwiftStorageAdapter.class.getName() + ".bucketName";
+
+    static final String KEY_SCHEME = "sb"; // same scheme as the S3StorageAdapterSB for now
+    static final int BUFFER_SIZE_BYTES = 8192;
+    static final String DEFAULT_CHECKSUM_ALGORITHM = "md5";
+    static final String CHECKSUM_KEY = "checksum";
+    static final String ARTIFACT_URI_KEY = "uri";
+
+    protected final int storageBucketLength;
+    protected final String storageBucket;
+    protected final Account client;
+    
+    private final InternalBucket internalBucket;
+    private Container swiftContainer;
+    
+    // ctor for unit tests that do not connect
+    SwiftStorageAdapter(String storageBucket, int storageBucketLength) {
+        this.storageBucket = storageBucket;
+        this.storageBucketLength = storageBucketLength;
+        this.client = null;
+        this.internalBucket = new InternalBucket(storageBucket);
+    }
+    
+    public SwiftStorageAdapter() {
+        try {
+            File config = new File(System.getProperty("user.home") + "/config/" + CONFIG_FILENAME);
+            Properties props = new Properties();
+            props.load(new FileReader(config));
+            
+            StringBuilder sb = new StringBuilder();
+            sb.append("incomplete config: ");
+            boolean ok = true;
+            
+            final String suri = props.getProperty(CONF_ENDPOINT);
+            sb.append("\n\t" + CONF_ENDPOINT + ": ");
+            if (suri == null) {
+                sb.append("MISSING");
+                ok = false;
+            } else {
+                sb.append("OK");
+            }
+
+            final String sbl = props.getProperty(CONF_SBLEN);
+            sb.append("\n\t" + CONF_SBLEN + ": ");
+            if (sbl == null) {
+                sb.append("MISSING");
+                ok = false;
+            } else {
+                sb.append("OK");
+            }
+
+            final String bn = props.getProperty(CONF_BUCKET);
+            sb.append("\n\t" + CONF_BUCKET + ": ");
+            if (bn == null) {
+                sb.append("MISSING");
+                ok = false;
+            } else {
+                sb.append("OK");
+            }
+            
+            final String user = props.getProperty(CONF_USER);
+            sb.append("\n\t" + CONF_USER + ": ");
+            if (user == null) {
+                sb.append("MISSING");
+                ok = false;
+            } else {
+                sb.append("OK");
+            }
+            
+            final String key = props.getProperty(CONF_KEY);
+            sb.append("\n\t" + CONF_KEY + ": ");
+            if (bn == null) {
+                sb.append("MISSING");
+                ok = false;
+            } else {
+                sb.append("OK");
+            }
+            
+            if (!ok) {
+                throw new IllegalStateException(sb.toString());
+            }
+           
+            URL authURL = new URL(suri);
+            
+            AccessProvider hack = new AuthenticationMethod.AccessProvider() {
+                @Override
+                public Access authenticate() {
+                    log.debug("AccessProvider.authenticate - START");
+                    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                    HttpGet login = new HttpGet(authURL, bos);
+                    login.setFollowRedirects(true);
+                    login.setRequestProperty("X-Auth-User", user);
+                    login.setRequestProperty("X-Auth-Key", key);
+                    login.run();
+                    log.debug("auth: " + login.getResponseCode() + " " + login.getContentType());
+                    if (login.getThrowable() != null) {
+                        throw new RuntimeException("auth failure", login.getThrowable());
+                    }
+                    String storageURL = login.getResponseHeader("X-Storage-Url");
+                    //String storageToken = login.getResponseHeader("X-Storage-Token");
+                    String authToken = login.getResponseHeader("X-Auth-Token");
+                    log.debug("storageURL: " + storageURL);
+                    //log.debug("storageToken: " + storageToken);
+                    log.debug("authToken: " + authToken);
+                    
+                    AccessWorkaroundHack ret = new AccessWorkaroundHack();
+                    ret.storageURL = storageURL.replace("http://", "https://").replace(":8080", "");
+                    ret.token = authToken;
+                    
+                    log.debug("AccessProvider.authenticate - DONE");
+                    return ret;
+                }
+            };
+            
+            this.storageBucket = bn;
+            this.storageBucketLength = Integer.parseInt(sbl);
+            AccountConfig ac = new AccountConfig();
+
+            // work around because uvic ceph auth returns wrong storage url
+            ac.setAccessProvider(hack);
+            ac.setAuthenticationMethod(AuthenticationMethod.EXTERNAL);
+            
+            //ac.setAuthenticationMethod(AuthenticationMethod.BASIC);
+            //ac.setUsername(user);
+            //ac.setPassword(key);
+            //ac.setAuthUrl(suri);
+            //ac.setTenantId("swift");
+            
+            this.client = new AccountFactory(ac).createAccount();
+            
+            this.internalBucket = new InternalBucket(storageBucket);
+            init();
+        } catch (Exception fatal) {
+            throw new RuntimeException("invalid config", fatal);
+        }
+    }
+
+    private static class AccessWorkaroundHack implements Access {
+
+        private String token;
+        private String storageURL;
+        
+        @Override
+        public void setPreferredRegion(String string) {
+            //ignore
+        }
+
+        @Override
+        public String getToken() {
+            return token;
+        }
+
+        @Override
+        public String getInternalURL() {
+            return null;
+        }
+
+        @Override
+        public String getPublicURL() {
+            return storageURL;
+        }
+
+        @Override
+        public boolean isTenantSupplied() {
+            return true; // via {username}:{tenant}
+        }
+
+        @Override
+        public String getTempUrlPrefix(TempUrlHashPrefixSource tuhps) {
+            return null;
+        }
+        
+    }
+    
+    private void init() {
+        this.swiftContainer = client.getContainer(internalBucket.name);
+        if (swiftContainer.exists()) {
+            log.debug("container: " + swiftContainer.getName() + " [exists]");
+            return;
+        }
+        swiftContainer.create();
+        log.debug("container: " + swiftContainer.getName() + " [created]");
+    }
+    
+    static class InternalBucket {
+        String name;
+        
+        InternalBucket(String name) {
+            this.name = name; 
+        }
+
+        @Override
+        public String toString() {
+            return "InternalBucket[" + name + "]";
+        }
+    }
+    
+    // internal format for object identifier is sb:{hex}:{uuid} and we re-use hex as the storageBucket
+    StorageLocation generateStorageLocation() {
+        String id = UUID.randomUUID().toString();
+        String pre = InventoryUtil.computeBucket(URI.create(id), storageBucketLength);
+        StorageLocation ret = new StorageLocation(URI.create(KEY_SCHEME + ":" + pre + ":" + id));
+        ret.storageBucket = pre;
+        return ret;
+    }
+    
+    InternalBucket toInternalBucket(StorageLocation loc) {
+        return internalBucket;
+    }
+    
+    protected StorageLocation toExternal(InternalBucket bucket, String key) {
+        // ignore bucket
+        // extract scheme from the key
+        String[] parts = key.split(":");
+        if (parts.length != 3 || !KEY_SCHEME.equals(parts[0])) {
+            throw new IllegalStateException("invalid object key: " + key + " from bucket: " + bucket);
+        }
+        StorageLocation ret = new StorageLocation(URI.create(key));
+        ret.storageBucket = parts[1];
+        return ret;
+    }
+    
+    private InputStream toObjectInputStream(final StorageLocation storageLocation) throws ResourceNotFoundException {
+        String bucket = toInternalBucket(storageLocation).name;
+        String key = storageLocation.getStorageID().toASCIIString();
+        StoredObject obj = swiftContainer.getObject(key);
+        if (!obj.exists()) {
+            throw new ResourceNotFoundException("not found: " + storageLocation);
+        }
+        return obj.downloadObjectAsInputStream();
+    }
+
+    private StorageMetadata toStorageMetadata(StorageLocation loc, URI md5, long contentLength, 
+            final URI artifactURI, Date lastModified) {
+        StorageMetadata storageMetadata = new StorageMetadata(loc, md5, contentLength);
+        storageMetadata.artifactURI = artifactURI;
+        storageMetadata.contentLastModified = lastModified;
+        return storageMetadata;
+    }
+
+    /**
+     * Get from storage the artifact identified by storageLocation.
+     *
+     * @param storageLocation The storage location containing storageID and storageBucket.
+     * @param dest The destination stream.
+     * @throws ResourceNotFoundException If the artifact could not be found.
+     * @throws ReadException If the storage system failed to stream.
+     * @throws WriteException If writing failed.
+     * @throws StorageEngageException If the adapter failed to interact with storage.
+     */
+    @Override
+    public void get(StorageLocation storageLocation, OutputStream dest)
+            throws ResourceNotFoundException, ReadException, WriteException, StorageEngageException {
+        log.debug("get: " + storageLocation);
+        try (final InputStream inputStream = toObjectInputStream(storageLocation)) {
+            ThreadedIO tio = new ThreadedIO(BUFFER_SIZE_BYTES, 8);
+            tio.ioLoop(dest, inputStream);
+        } catch (ReadException | WriteException e) {
+            // Handle before the IOException below so it's not wrapped into that catch.
+            throw e;
+        } catch (IOException ex) {
+            throw new ReadException("close stream failure", ex);
+        }
+    }
+
+    /**
+     * Get from storage the artifact identified by storageLocation with cutout specifications. Currently needs full
+     * implementation.
+     *
+     * @param storageLocation The storage location containing storageID and storageBucket.
+     * @param dest The destination stream.
+     * @param cutouts Cutouts to be applied to the artifact
+     * @throws ResourceNotFoundException If the artifact could not be found.
+     * @throws ReadException If the storage system failed to stream.
+     * @throws WriteException If writing failed.
+     * @throws StorageEngageException If the adapter failed to interact with storage.
+     */
+    @Override
+    public void get(StorageLocation storageLocation, OutputStream dest, Set<String> cutouts)
+            throws ResourceNotFoundException, ReadException, WriteException, StorageEngageException {
+        throw new UnsupportedOperationException();
+    }
+
+    // internal bucket management used for init, dynamic buckets, and intTest cleanup
+    void createBucket(InternalBucket bucket) throws ResourceAlreadyExistsException {
+        throw new UnsupportedOperationException();
+    }
+    
+    void deleteBucket(InternalBucket bucket) throws ResourceNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Write an artifact to storage.
+     * The value of storageBucket in the returned StorageMetadata and StorageLocation can be used to
+     * retrieve batches of artifacts in some of the iterator signatures defined in this interface.
+     * Batches of artifacts can be listed by bucket in two of the iterator methods in this interface.
+     * If storageBucket is null then the caller will not be able perform bucket-based batch
+     * validation through the iterator methods.
+     *
+     * @param newArtifact known information about the incoming artifact
+     * @param source stream from which to read
+     * @return storage metadata after write
+     * @throws ca.nrc.cadc.io.ByteLimitExceededException
+     *
+     * @throws IncorrectContentChecksumException checksum of the data stream did not match the value in newArtifact
+     * @throws IncorrectContentLengthException number bytes read did not match the value in newArtifact
+     * @throws ReadException If the client failed to read the stream.
+     * @throws WriteException If the storage system failed to stream.
+     * @throws StorageEngageException If the adapter failed to interact with storage.
+     */
+    @Override
+    public StorageMetadata put(NewArtifact newArtifact, InputStream source)
+            throws ByteLimitExceededException, 
+            IncorrectContentChecksumException, IncorrectContentLengthException, 
+            ReadException, WriteException,
+            StorageEngageException {
+        InventoryUtil.assertNotNull(SwiftStorageAdapter.class, "newArtifact", newArtifact);
+        log.debug("put: " + newArtifact);
+        
+        if (newArtifact.contentLength != null && newArtifact.contentLength > CEPH_UPLOAD_LIMIT) {
+            throw new ByteLimitExceededException("put exceeds size limit (" + CEPH_UPLOAD_LIMIT_MSG + ") for simple stream", CEPH_UPLOAD_LIMIT);
+        }
+        
+        final StorageLocation loc = generateStorageLocation();
+
+        try {
+            String alg = DEFAULT_CHECKSUM_ALGORITHM;
+            if (newArtifact.contentChecksum != null) {
+                alg = newArtifact.contentChecksum.getScheme(); // TODO: try sha1 in here
+            }
+            MessageDigest md = MessageDigest.getInstance(DEFAULT_CHECKSUM_ALGORITHM);
+            DigestInputStream dis = new DigestInputStream(source, md);
+            ByteCountInputStream bcis = new ByteCountInputStream(dis);
+
+            StoredObject obj = swiftContainer.getObject(loc.getStorageID().toASCIIString());
+            UploadInstructions up = new UploadInstructions(bcis);
+            if (newArtifact.contentChecksum != null && "MD5".equalsIgnoreCase(newArtifact.contentChecksum.getScheme())) {
+                up.setMd5(newArtifact.contentChecksum.getSchemeSpecificPart());
+            }
+
+            try {
+                obj.uploadObject(up);
+            } catch (CommandException ex) {
+                if (bcis.getByteCount() >= CEPH_UPLOAD_LIMIT && hasWriteFailSocketException(ex)) {
+                    throw new ByteLimitExceededException("put exceeds size limit (" + CEPH_UPLOAD_LIMIT_MSG + ") for simple stream", CEPH_UPLOAD_LIMIT);
+                }
+                throw ex;
+            }
+            
+            String etag = obj.getEtag();
+            String slm = obj.getLastModified();
+            log.debug("after upload: etag=" + etag + " len=" + obj.getContentLength());
+                    
+            final URI contentChecksum = URI.create(DEFAULT_CHECKSUM_ALGORITHM + ":" + HexUtil.toHex(md.digest()));
+            
+            if (newArtifact.contentChecksum != null && !contentChecksum.equals(newArtifact.contentChecksum)) {
+                obj.delete();
+                throw new PreconditionFailedException("checksum mismatch: " + newArtifact.contentChecksum + " != " + contentChecksum);
+            }
+            final Long contentLength = obj.getContentLength();
+            if (newArtifact.contentLength != null && !contentLength.equals(newArtifact.contentLength)) {
+                obj.delete();
+                throw new PreconditionFailedException("length mismatch: " + newArtifact.contentLength + " != " + contentLength);
+            }
+           
+            final Date lastModified = obj.getLastModifiedAsDate();
+            
+            Map<String,Object> metadata = new TreeMap<>();
+            metadata.put(ARTIFACT_URI_KEY, newArtifact.getArtifactURI().toASCIIString());
+            metadata.put(CHECKSUM_KEY, contentChecksum.toASCIIString());
+            obj.setMetadata(metadata);
+            //obj.saveMetadata();
+            
+            return toStorageMetadata(loc, contentChecksum, contentLength, newArtifact.getArtifactURI(), lastModified);
+        } catch (Md5ChecksumException ex) {
+            //swift detected
+            throw new PreconditionFailedException("checksum mismatch: " + newArtifact.contentChecksum + " did not match content");
+        } catch (NoSuchAlgorithmException ex) {
+            throw new RuntimeException("failed to create MessageDigest: " + DEFAULT_CHECKSUM_ALGORITHM);
+        }
+    }
+
+    // ceph+swift API: when writing past limit the stream gets closed 
+    private boolean  hasWriteFailSocketException(Exception ex) {
+        Throwable cause = ex.getCause();
+        while (cause != null) {
+            if (cause instanceof SocketException && "broken pipe (write failed)".equalsIgnoreCase(cause.getMessage())) {
+                return  true;
+            }
+            cause = cause.getCause();
+        }
+        return false;
+    }
+        
+    // used by intTest
+    boolean exists(StorageLocation storageLocation) throws StorageEngageException {
+        log.debug("exists: " + storageLocation);
+        String key = storageLocation.getStorageID().toASCIIString();
+        try {
+            StoredObject obj = swiftContainer.getObject(key);
+            return obj.exists();
+        } catch (Exception ex) {
+            throw new StorageEngageException("failed to delete: " + storageLocation, ex);
+        }
+    }
+    
+    /**
+     * Delete from storage the artifact identified by storageLocation.
+     *
+     * @param storageLocation Identifies the artifact to delete.
+     * @throws ResourceNotFoundException If the artifact could not be found.
+     * @throws IOException If an unrecoverable error occurred.
+     * @throws StorageEngageException If the adapter failed to interact with storage.
+     * @throws TransientException If an unexpected, temporary exception occurred.
+     */
+    @Override
+    public void delete(StorageLocation storageLocation)
+            throws ResourceNotFoundException, IOException, StorageEngageException, TransientException {
+        log.debug("delete: " + storageLocation);
+        String key = storageLocation.getStorageID().toASCIIString();
+        
+        // invalid object found by StorageMetadataIterator
+        if (key.startsWith("invalid:")) {
+            key = key.replace("invalid:", "");
+        }
+        try {
+            StoredObject obj = swiftContainer.getObject(key);
+            if (obj.exists()) {
+                obj.delete();
+                return;
+            }
+        } catch (Exception ex) {
+            throw new StorageEngageException("failed to delete: " + storageLocation, ex);
+        }
+        throw new ResourceNotFoundException("not found: " + storageLocation);
+    }
+
+    @Override
+    public Iterator<StorageMetadata> iterator() throws StorageEngageException, TransientException {
+        return iterator(null);
+    }
+
+    @Override
+    public Iterator<StorageMetadata> iterator(String bucketPrefix) throws StorageEngageException, TransientException {
+        return new StorageMetadataIterator(bucketPrefix);
+    }
+
+    /**
+     * Get the set of items in the given bucket.
+     *
+     * @param storageBucket Only iterate over items in this bucket.
+     * @return An iterator over an ordered list of items in this storage bucket.
+     *
+     * @throws StorageEngageException If the adapter failed to interact with storage.
+     * @throws TransientException If an unexpected, temporary exception occurred.
+     */
+    public SortedSet<StorageMetadata> list(String storageBucket)
+            throws StorageEngageException, TransientException {
+        SortedSet<StorageMetadata> ret = new TreeSet<>();
+        Iterator<StorageMetadata> i = iterator(storageBucket);
+        while (i.hasNext()) {
+            ret.add(i.next());
+        }
+        return ret;
+    }
+    
+    private class StorageMetadataIterator implements Iterator<StorageMetadata> {
+
+        private static final int BATCH_SIZE = 5;
+        private Iterator<DirectoryOrObject> objectIterator;
+        private final String bucketPrefix;
+        
+        private String nextMarkerKey; // name of last item returned by next()
+        private boolean done = false;
+
+        public StorageMetadataIterator(String bucketPrefix) {
+            if (bucketPrefix != null) {
+                this.bucketPrefix = KEY_SCHEME + ":" + bucketPrefix;
+            } else {
+                this.bucketPrefix = null;
+            }
+        }
+        
+        @Override
+        public boolean hasNext() {
+            if (done) {
+                return false;
+            }
+            
+            if (objectIterator == null || !objectIterator.hasNext()) {
+                Collection<DirectoryOrObject> list = swiftContainer.listDirectory(bucketPrefix, '/', nextMarkerKey, BATCH_SIZE);
+                log.debug("StorageMetadataIterator bucketPrefix: " + bucketPrefix + " size: " + list.size() + " from " + nextMarkerKey);
+                if (!list.isEmpty()) {
+                    objectIterator = list.iterator();
+                } else {
+                    objectIterator = null;
+                    done = true;
+                    log.debug("StorageMetadataIterator: done");
+                }
+            }
+
+            if (objectIterator == null) {
+                return false;
+            }
+
+            return objectIterator.hasNext();
+        }
+
+        @Override
+        public StorageMetadata next() {
+            if (objectIterator == null || !objectIterator.hasNext()) {
+                throw new NoSuchElementException();
+            }
+            DirectoryOrObject o = objectIterator.next();
+            StoredObject obj = o.getAsObject();
+            log.debug("next: name=" + obj.getName() + " len=" + obj.getContentLength());
+            this.nextMarkerKey = obj.getName();
+            
+            try {
+                final StorageLocation loc = toExternal(internalBucket, obj.getName());
+            
+                Map<String,Object> meta = obj.getMetadata();
+                String scs = (String) meta.get(CHECKSUM_KEY);
+                String auri = (String) meta.get(ARTIFACT_URI_KEY);
+
+                if (scs == null || auri == null) {
+                    // put failed to set metadata after writing the file: invalid
+                    log.debug("found invalid: " + loc);
+                    return new StorageMetadata(new StorageLocation(URI.create("invalid:" + obj.getName())));
+                }
+
+                URI md5 = URI.create(scs);
+                URI artifactURI = URI.create(auri);
+
+                return toStorageMetadata(loc, md5, obj.getContentLength(), artifactURI, obj.getLastModifiedAsDate());
+            } catch (IllegalStateException ex) {
+                // this form is sufficient be used for delete
+                return new StorageMetadata(new StorageLocation(URI.create("invalid:" + obj.getName())));
+            }
+        }
+        
+    }
+}

--- a/cadc-storage-adapter-ceph/src/main/java/org/opencadc/inventory/storage/swift/SwiftStorageAdapter.java
+++ b/cadc-storage-adapter-ceph/src/main/java/org/opencadc/inventory/storage/swift/SwiftStorageAdapter.java
@@ -609,7 +609,7 @@ public class SwiftStorageAdapter  implements StorageAdapter {
     
     private class StorageMetadataIterator implements Iterator<StorageMetadata> {
 
-        private static final int BATCH_SIZE = 5;
+        private static final int BATCH_SIZE = 1000;
         private Iterator<DirectoryOrObject> objectIterator;
         private final String bucketPrefix;
         

--- a/cadc-storage-adapter-ceph/src/test/java/org/opencadc/inventory/storage/swift/SwiftStorageAdapterTest.java
+++ b/cadc-storage-adapter-ceph/src/test/java/org/opencadc/inventory/storage/swift/SwiftStorageAdapterTest.java
@@ -1,0 +1,106 @@
+/*
+************************************************************************
+*******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+**************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+*
+*  (c) 2020.                            (c) 2020.
+*  Government of Canada                 Gouvernement du Canada
+*  National Research Council            Conseil national de recherches
+*  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+*  All rights reserved                  Tous droits réservés
+*
+*  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+*  expressed, implied, or               énoncée, implicite ou légale,
+*  statutory, of any kind with          de quelque nature que ce
+*  respect to the software,             soit, concernant le logiciel,
+*  including without limitation         y compris sans restriction
+*  any warranty of merchantability      toute garantie de valeur
+*  or fitness for a particular          marchande ou de pertinence
+*  purpose. NRC shall not be            pour un usage particulier.
+*  liable in any event for any          Le CNRC ne pourra en aucun cas
+*  damages, whether direct or           être tenu responsable de tout
+*  indirect, special or general,        dommage, direct ou indirect,
+*  consequential or incidental,         particulier ou général,
+*  arising from the use of the          accessoire ou fortuit, résultant
+*  software.  Neither the name          de l'utilisation du logiciel. Ni
+*  of the National Research             le nom du Conseil National de
+*  Council of Canada nor the            Recherches du Canada ni les noms
+*  names of its contributors may        de ses  participants ne peuvent
+*  be used to endorse or promote        être utilisés pour approuver ou
+*  products derived from this           promouvoir les produits dérivés
+*  software without specific prior      de ce logiciel sans autorisation
+*  written permission.                  préalable et particulière
+*                                       par écrit.
+*
+*  This file is part of the             Ce fichier fait partie du projet
+*  OpenCADC project.                    OpenCADC.
+*
+*  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+*  you can redistribute it and/or       vous pouvez le redistribuer ou le
+*  modify it under the terms of         modifier suivant les termes de
+*  the GNU Affero General Public        la “GNU Affero General Public
+*  License as published by the          License” telle que publiée
+*  Free Software Foundation,            par la Free Software Foundation
+*  either version 3 of the              : soit la version 3 de cette
+*  License, or (at your option)         licence, soit (à votre gré)
+*  any later version.                   toute version ultérieure.
+*
+*  OpenCADC is distributed in the       OpenCADC est distribué
+*  hope that it will be useful,         dans l’espoir qu’il vous
+*  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+*  without even the implied             GARANTIE : sans même la garantie
+*  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+*  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+*  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+*  General Public License for           Générale Publique GNU Affero
+*  more details.                        pour plus de détails.
+*
+*  You should have received             Vous devriez avoir reçu une
+*  a copy of the GNU Affero             copie de la Licence Générale
+*  General Public License along         Publique GNU Affero avec
+*  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+*  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+*                                       <http://www.gnu.org/licenses/>.
+*
+************************************************************************
+*/
+
+package org.opencadc.inventory.storage.swift;
+
+import org.apache.log4j.Logger;
+import org.junit.Assert;
+import org.junit.Test;
+import org.opencadc.inventory.StorageLocation;
+
+/**
+ *
+ * @author pdowler
+ */
+public class SwiftStorageAdapterTest {
+    private static final Logger log = Logger.getLogger(SwiftStorageAdapterTest.class);
+
+    SwiftStorageAdapter adapter;
+    
+    public SwiftStorageAdapterTest() { 
+        this.adapter = new SwiftStorageAdapter("test-bucket", 0);
+    }
+    
+    @Test
+    public void testGenerateID() throws Exception {
+        // enough to verify that randomness in the scheme doesn't create invalid URI?
+        for (int i = 0; i < 20; i++) {
+            StorageLocation loc = adapter.generateStorageLocation();
+            log.info("testGenerateID: " + loc);
+        }
+    }
+    
+    @Test
+    public void testBucketeering() throws Exception {
+        StorageLocation loc = adapter.generateStorageLocation();
+        log.info("testBucketeering created: " + loc);
+        
+        SwiftStorageAdapter.InternalBucket ibucket = adapter.toInternalBucket(loc);
+        StorageLocation actual = adapter.toExternal(ibucket, loc.getStorageID().toASCIIString());
+        Assert.assertEquals(loc, actual);
+    }
+}

--- a/cadc-storage-adapter-fs/build.gradle
+++ b/cadc-storage-adapter-fs/build.gradle
@@ -15,13 +15,13 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '0.6'
+version = '0.6.1'
 
 dependencies {
     compile 'log4j:log4j:[1.2,)'
     compile 'org.opencadc:cadc-util:[1.2.31,)'
     compile 'org.opencadc:cadc-inventory:[0.3,)'
-    compile 'org.opencadc:cadc-storage-adapter:[0.3,)'
+    compile 'org.opencadc:cadc-storage-adapter:[0.6,)'
 
     testCompile 'junit:junit:[4.0,)'
 }

--- a/cadc-storage-adapter/build.gradle
+++ b/cadc-storage-adapter/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '0.5.1'
+version = '0.6'
 
 dependencies {
     compile 'log4j:log4j:[1.2,)'

--- a/cadc-storage-adapter/src/main/java/org/opencadc/inventory/storage/StorageMetadata.java
+++ b/cadc-storage-adapter/src/main/java/org/opencadc/inventory/storage/StorageMetadata.java
@@ -92,6 +92,13 @@ public class StorageMetadata implements Comparable<StorageMetadata> {
     public String contentEncoding;
     public String contentType;
     
+    /**
+     * Constructor for a valid stored object.
+     * 
+     * @param storageLocation
+     * @param contentChecksum
+     * @param contentLength 
+     */
     public StorageMetadata(StorageLocation storageLocation, URI contentChecksum, Long contentLength) {
         InventoryUtil.assertNotNull(StorageMetadata.class, "storageLocation", storageLocation);
         InventoryUtil.assertNotNull(StorageMetadata.class, "contentChecksum", contentChecksum);
@@ -103,7 +110,23 @@ public class StorageMetadata implements Comparable<StorageMetadata> {
         this.contentChecksum = contentChecksum;
         this.contentLength = contentLength;
     }
+    
+    /**
+     * Constructor for an invalid stored object that should be cleaned up.
+     * 
+     * @param storageLocation 
+     */
+    public StorageMetadata(StorageLocation storageLocation) {
+        InventoryUtil.assertNotNull(StorageMetadata.class, "storageLocation", storageLocation);
+        this.storageLocation = storageLocation;
+        this.contentChecksum = null;
+        this.contentLength = null;
+    }
 
+    public boolean isValid() {
+        return contentChecksum != null;
+    }
+    
     public StorageLocation getStorageLocation() {
         return storageLocation;
     }

--- a/minoc/src/main/java/org/opencadc/minoc/PutAction.java
+++ b/minoc/src/main/java/org/opencadc/minoc/PutAction.java
@@ -177,7 +177,7 @@ public class PutAction extends ArtifactAction {
 
         InputStream in = (InputStream) syncInput.getContent(INLINE_CONTENT_TAG);
         if (in == null) {
-            throw new ReadException("invalid input: no content");
+            throw new IllegalArgumentException("invalid input: no content");
         }
 
         profiler.checkpoint("content.init");

--- a/minoc/src/main/java/org/opencadc/minoc/PutAction.java
+++ b/minoc/src/main/java/org/opencadc/minoc/PutAction.java
@@ -176,6 +176,9 @@ public class PutAction extends ArtifactAction {
         final Profiler profiler = new Profiler(PutAction.class);
 
         InputStream in = (InputStream) syncInput.getContent(INLINE_CONTENT_TAG);
+        if (in == null) {
+            throw new ReadException("invalid input: no content");
+        }
 
         profiler.checkpoint("content.init");
 


### PR DESCRIPTION
- Artifact now validates checksum URI (scheme, syntax, and byte length of hex)
- StorageAdapter API change: allow returned invalid StorageMetadata to support cleanup
- permissions bug fixes in minoc and raven
- no content error handling in minoc
