### PR TITLE
implement artifact row locking for all code that updates artifacts: resolves #146 CADC-8507

### DIFF
--- a/cadc-inventory-db/build.gradle
+++ b/cadc-inventory-db/build.gradle
@@ -18,7 +18,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '0.10'
+version = '0.10.1'
 
 mainClassName = 'org.opencadc.inventory.db.version.Main'
 

--- a/cadc-inventory-db/src/main/java/org/opencadc/inventory/db/AbstractDAO.java
+++ b/cadc-inventory-db/src/main/java/org/opencadc/inventory/db/AbstractDAO.java
@@ -102,7 +102,6 @@ public abstract class AbstractDAO<T extends Entity> {
 
     protected SQLGenerator gen;
     protected DataSource dataSource;
-    protected TransactionManager txnManager;
     
     protected final boolean origin;
 
@@ -120,7 +119,6 @@ public abstract class AbstractDAO<T extends Entity> {
         this(dao.origin);
         this.gen = dao.getSQLGenerator();
         this.dataSource = dao.getDataSource();
-        this.txnManager = dao.getTransactionManager();
     }
 
     protected MessageDigest getDigest() {

--- a/cadc-inventory-db/src/main/java/org/opencadc/inventory/db/AbstractDAO.java
+++ b/cadc-inventory-db/src/main/java/org/opencadc/inventory/db/AbstractDAO.java
@@ -103,16 +103,11 @@ public abstract class AbstractDAO<T extends Entity> {
     protected SQLGenerator gen;
     protected DataSource dataSource;
     protected TransactionManager txnManager;
-    protected MessageDigest digest;
+    
     protected final boolean origin;
 
     protected AbstractDAO(boolean origin) {
         this.origin = origin;
-        try {
-            this.digest = MessageDigest.getInstance("MD5");
-        } catch (NoSuchAlgorithmException ex) {
-            throw new RuntimeException("FATAL: no MD5 digest algorithm available", ex);
-        }
     }
     
     /**
@@ -128,6 +123,14 @@ public abstract class AbstractDAO<T extends Entity> {
         this.txnManager = dao.getTransactionManager();
     }
 
+    protected MessageDigest getDigest() {
+        try {
+            return MessageDigest.getInstance("MD5");
+        } catch (NoSuchAlgorithmException ex) {
+            throw new RuntimeException("FATAL: no MD5 digest algorithm available", ex);
+        }
+    }
+    
     /**
      * Get the DataSource in use by the DAO. This is intended so that
      * applications can include other SQL statements along with DAO operations
@@ -146,17 +149,16 @@ public abstract class AbstractDAO<T extends Entity> {
     }
 
     /**
-     * Get the TransactionManager that controls transactions using this DAOs
-     * DataSource.
+     * Get a new TransactionManager that controls transactions using this DAOs
+     * DataSource. For thread safe use of a DAO class, this method creates a new 
+     * TransactionManager each time it is called. The caller must maintain a reference 
+     * to the instance for the life of a transaction.
      *
      * @return the TransactionManager
      */
     public TransactionManager getTransactionManager() {
         checkInit();
-        if (txnManager == null) {
-            this.txnManager = new DatabaseTransactionManager(dataSource);
-        }
-        return txnManager;
+        return new DatabaseTransactionManager(dataSource);
     }
 
     public Map<String, Class> getParams() {
@@ -330,8 +332,8 @@ public abstract class AbstractDAO<T extends Entity> {
     // assign metaChecksum and update lastModified
     private boolean updateEntity(T entity, Entity cur, Date now, boolean timestampUpdate) {
         log.debug("updateEntity: " + entity);
+        MessageDigest digest = getDigest();
         
-        digest.reset(); // just in case
         InventoryUtil.assignMetaChecksum(entity, entity.computeMetaChecksum(digest));
         
         boolean delta = false;

--- a/cadc-inventory-db/src/main/java/org/opencadc/inventory/db/DeletedArtifactEventDAO.java
+++ b/cadc-inventory-db/src/main/java/org/opencadc/inventory/db/DeletedArtifactEventDAO.java
@@ -3,7 +3,7 @@
 *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 *
-*  (c) 2020.                            (c) 2020.
+*  (c) 2019.                            (c) 2019.
 *  Government of Canada                 Gouvernement du Canada
 *  National Research Council            Conseil national de recherches
 *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -65,86 +65,30 @@
 ************************************************************************
 */
 
-package org.opencadc.fenwick;
+package org.opencadc.inventory.db;
 
-import ca.nrc.cadc.auth.SSLUtil;
-import ca.nrc.cadc.util.FileUtil;
-import ca.nrc.cadc.util.HexUtil;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.io.IOException;
-import java.net.URI;
-import java.util.MissingResourceException;
-import java.util.Properties;
 import java.util.UUID;
-import javax.security.auth.Subject;
-import org.apache.log4j.Logger;
+import org.opencadc.inventory.DeletedArtifactEvent;
 
 /**
- *
+ * Fire/persist a DeletedArtifactEvent.
+ * 
  * @author pdowler
  */
-public class TestUtil {
-    private static final Logger log = Logger.getLogger(TestUtil.class);
-    static String INVENTORY_SERVER = "FENWICK_TEST";
-    static String INVENTORY_DATABASE = "cadctest";
-    static String INVENTORY_SCHEMA = "inventory";
-    static String LUSKAN_SERVER = "LUSKAN_TEST";
-    static String LUSKAN_SCHEMA = "inventory";
-    static String LUSKAN_DATABASE = "cadctest";
-    static URI LUSKAN_URI = URI.create("ivo://cadc.nrc.ca/luskan");
-    
-    static String ZERO_BYTES_MD5 = "md5:d41d8cd98f00b204e9800998ecf8427e";
-
-    static {
-        try {
-            File opt = FileUtil.getFileFromResource("intTest.properties", TestUtil.class);
-            if (opt.exists()) {
-                Properties props = new Properties();
-                props.load(new FileReader(opt));
-
-                if (props.containsKey("inventoryServer")) {
-                    INVENTORY_SERVER = props.getProperty("inventoryServer").trim();
-                }
-                if (props.containsKey("inventoryDatabase")) {
-                    INVENTORY_DATABASE = props.getProperty("inventoryDatabase").trim();
-                }
-                if (props.containsKey("inventorySchema")) {
-                    INVENTORY_SCHEMA = props.getProperty("inventorySchema").trim();
-                }
-                if (props.containsKey("luskanServer")) {
-                    LUSKAN_SERVER = props.getProperty("luskanServer").trim();
-                }
-                if (props.containsKey("luskanSchema")) {
-                    LUSKAN_SCHEMA = props.getProperty("luskanSchema").trim();
-                }
-                if (props.containsKey("luskanDatabase")) {
-                    LUSKAN_DATABASE = props.getProperty("luskanDatabase").trim();
-                }
-                if (props.containsKey("luskanURI")) {
-                    LUSKAN_URI = URI.create(props.getProperty("luskanURI").trim());
-                }
-            }
-        } catch (MissingResourceException | FileNotFoundException noFileException) {
-            log.debug("No intTest.properties supplied.  Using defaults.");
-        } catch (IOException oops) {
-            throw new RuntimeException(oops.getMessage(), oops);
-        }
-
-        log.debug("intTest database config: " + INVENTORY_SERVER + " " + INVENTORY_DATABASE + " "
-                  + INVENTORY_SCHEMA);
-    }
-    
-    private TestUtil() { 
+public class DeletedArtifactEventDAO extends AbstractDAO<DeletedArtifactEvent> {
+    public DeletedArtifactEventDAO() { 
+        super(true);
     }
 
-    static Subject getConfiguredSubject() {
-        return SSLUtil.createSubject(new File(System.getProperty("user.home") + "/.ssl/cadcproxy.pem"));
+    public DeletedArtifactEventDAO(boolean origin) {
+        super(origin);
+    }
+
+    public DeletedArtifactEventDAO(AbstractDAO<?> dao) {
+        super(dao);
     }
     
-    static URI getRandomMD5() {
-        UUID uuid = UUID.randomUUID();
-        return URI.create("md5:" + HexUtil.toHex(uuid.getMostSignificantBits()) + HexUtil.toHex(uuid.getLeastSignificantBits()));
+    public DeletedArtifactEvent get(UUID id) {
+        return super.get(DeletedArtifactEvent.class, id);
     }
 }

--- a/cadc-inventory-db/src/main/java/org/opencadc/inventory/db/DeletedStorageLocationEventDAO.java
+++ b/cadc-inventory-db/src/main/java/org/opencadc/inventory/db/DeletedStorageLocationEventDAO.java
@@ -67,24 +67,28 @@
 
 package org.opencadc.inventory.db;
 
-import org.opencadc.inventory.Entity;
-
+import java.util.UUID;
+import org.opencadc.inventory.DeletedStorageLocationEvent;
 
 /**
- * Fire/persist a deleted entity event.
+ * Fire/persist a DeletedStorageLocationEvent.
  * 
  * @author pdowler
  */
-public class DeletedEventDAO<T extends Entity> extends AbstractDAO<T> {
-    public DeletedEventDAO() { 
+public class DeletedStorageLocationEventDAO extends AbstractDAO<DeletedStorageLocationEvent> {
+    public DeletedStorageLocationEventDAO() { 
         super(true);
     }
 
-    public DeletedEventDAO(boolean origin) {
+    public DeletedStorageLocationEventDAO(boolean origin) {
         super(origin);
     }
 
-    public DeletedEventDAO(AbstractDAO<?> dao) {
+    public DeletedStorageLocationEventDAO(AbstractDAO<?> dao) {
         super(dao);
+    }
+    
+    public DeletedStorageLocationEvent get(UUID id) {
+        return super.get(DeletedStorageLocationEvent.class, id);
     }
 }

--- a/cadc-inventory-db/src/main/java/org/opencadc/inventory/db/HarvestStateDAO.java
+++ b/cadc-inventory-db/src/main/java/org/opencadc/inventory/db/HarvestStateDAO.java
@@ -90,9 +90,17 @@ public class HarvestStateDAO extends AbstractDAO<HarvestState> {
     }
     
     public HarvestState get(UUID id) {
-        return super.get(HarvestState.class, id);
+        HarvestState ret = super.get(HarvestState.class, id);
+        return ret;
     }
     
+    /**
+     * Get HarvestState for the specified name and resourceID (create if necessary).
+     * 
+     * @param name
+     * @param resourceID
+     * @return 
+     */
     public HarvestState get(String name, URI resourceID) {
         if (name == null || resourceID == null) {
             throw new IllegalArgumentException("name and resourceID cannot be null");
@@ -107,6 +115,9 @@ public class HarvestStateDAO extends AbstractDAO<HarvestState> {
             SQLGenerator.HarvestStateGet get = ( SQLGenerator.HarvestStateGet) gen.getEntityGet(HarvestState.class);
             get.setSource(name, resourceID);
             HarvestState o = get.execute(jdbc);
+            if (o == null) {
+                o = new HarvestState(name, resourceID);
+            }
             return o;
         } finally {
             long dt = System.currentTimeMillis() - t;

--- a/cadc-inventory-db/src/main/java/org/opencadc/inventory/db/HarvestStateDAO.java
+++ b/cadc-inventory-db/src/main/java/org/opencadc/inventory/db/HarvestStateDAO.java
@@ -97,9 +97,9 @@ public class HarvestStateDAO extends AbstractDAO<HarvestState> {
     /**
      * Get HarvestState for the specified name and resourceID (create if necessary).
      * 
-     * @param name
-     * @param resourceID
-     * @return 
+     * @param name name of the entity being harvested
+     * @param resourceID source of entities
+     * @return current (or new) HarvestState (never null)
      */
     public HarvestState get(String name, URI resourceID) {
         if (name == null || resourceID == null) {

--- a/cadc-inventory-util/build.gradle
+++ b/cadc-inventory-util/build.gradle
@@ -11,18 +11,22 @@ repositories {
     mavenLocal()
 }
 
+apply from: '../opencadc.gradle'
+
 sourceCompatibility = 1.8
+
 group = 'org.opencadc'
-version = '0.1.0'
+
+version = '0.1.1'
 
 dependencies {
     compile 'log4j:log4j:[1.2,)'
+    compile 'org.apache.commons:commons-dbcp2:[2.8.0,2.9.0)'
     compile 'org.opencadc:cadc-inventory:[0.7,1.0)'
     compile 'org.opencadc:cadc-util:[1.2,)'
     compile 'org.opencadc:cadc-gms:[1.0.0,)'
-
+    
     testCompile 'junit:junit:[4.0,)'
+    
+    intTestRuntime 'org.postgresql:postgresql:[42.2.8,)'
 }
-
-apply from: '../opencadc.gradle'
-

--- a/cadc-inventory-util/src/intTest/java/org/opencadc/inventory/util/DBUtilTest.java
+++ b/cadc-inventory-util/src/intTest/java/org/opencadc/inventory/util/DBUtilTest.java
@@ -1,0 +1,151 @@
+/*
+************************************************************************
+*******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+**************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+*
+*  (c) 2020.                            (c) 2020.
+*  Government of Canada                 Gouvernement du Canada
+*  National Research Council            Conseil national de recherches
+*  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+*  All rights reserved                  Tous droits réservés
+*
+*  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+*  expressed, implied, or               énoncée, implicite ou légale,
+*  statutory, of any kind with          de quelque nature que ce
+*  respect to the software,             soit, concernant le logiciel,
+*  including without limitation         y compris sans restriction
+*  any warranty of merchantability      toute garantie de valeur
+*  or fitness for a particular          marchande ou de pertinence
+*  purpose. NRC shall not be            pour un usage particulier.
+*  liable in any event for any          Le CNRC ne pourra en aucun cas
+*  damages, whether direct or           être tenu responsable de tout
+*  indirect, special or general,        dommage, direct ou indirect,
+*  consequential or incidental,         particulier ou général,
+*  arising from the use of the          accessoire ou fortuit, résultant
+*  software.  Neither the name          de l'utilisation du logiciel. Ni
+*  of the National Research             le nom du Conseil National de
+*  Council of Canada nor the            Recherches du Canada ni les noms
+*  names of its contributors may        de ses  participants ne peuvent
+*  be used to endorse or promote        être utilisés pour approuver ou
+*  products derived from this           promouvoir les produits dérivés
+*  software without specific prior      de ce logiciel sans autorisation
+*  written permission.                  préalable et particulière
+*                                       par écrit.
+*
+*  This file is part of the             Ce fichier fait partie du projet
+*  OpenCADC project.                    OpenCADC.
+*
+*  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+*  you can redistribute it and/or       vous pouvez le redistribuer ou le
+*  modify it under the terms of         modifier suivant les termes de
+*  the GNU Affero General Public        la “GNU Affero General Public
+*  License as published by the          License” telle que publiée
+*  Free Software Foundation,            par la Free Software Foundation
+*  either version 3 of the              : soit la version 3 de cette
+*  License, or (at your option)         licence, soit (à votre gré)
+*  any later version.                   toute version ultérieure.
+*
+*  OpenCADC is distributed in the       OpenCADC est distribué
+*  hope that it will be useful,         dans l’espoir qu’il vous
+*  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+*  without even the implied             GARANTIE : sans même la garantie
+*  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+*  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+*  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+*  General Public License for           Générale Publique GNU Affero
+*  more details.                        pour plus de détails.
+*
+*  You should have received             Vous devriez avoir reçu une
+*  a copy of the GNU Affero             copie de la Licence Générale
+*  General Public License along         Publique GNU Affero avec
+*  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+*  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+*                                       <http://www.gnu.org/licenses/>.
+*
+************************************************************************
+*/
+
+package org.opencadc.inventory.util;
+
+import ca.nrc.cadc.db.ConnectionConfig;
+import ca.nrc.cadc.db.DBConfig;
+import ca.nrc.cadc.util.Log4jInit;
+import java.sql.Connection;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ * @author pdowler
+ */
+public class DBUtilTest {
+    private static final Logger log = Logger.getLogger(DBUtilTest.class);
+
+    static {
+        Log4jInit.setLevel("org.opencadc.inventory.util", Level.INFO);
+    }
+    
+    public DBUtilTest() { 
+    }
+    
+    @Test
+    public void testCreatePool() {
+        String poolName = "jdbc/create-pool";
+        long maxWait = 6000L;
+        try {
+            DBConfig dbrc = new DBConfig();
+            ConnectionConfig cc = dbrc.getConnectionConfig("INVENTORY_TEST", "cadctest");
+            DBUtil.PoolConfig pc = new DBUtil.PoolConfig(cc, 2, maxWait, "select 123");
+            
+            DBUtil.createJNDIDataSource(poolName, pc);
+            
+            DataSource pool = DBUtil.findJNDIDataSource(poolName);
+            Assert.assertNotNull("pool", pool);
+            
+            Connection con1 = pool.getConnection();
+            Assert.assertNotNull("connection 1", con1);
+            log.info("connection 1: " + con1.getCatalog() + " " + con1.isValid(0));
+            
+            Connection con2 = pool.getConnection();
+            Assert.assertNotNull("connection 2", con2);
+            log.info("connection 2: " + con2.getCatalog() + " " + con2.isValid(0));
+            
+            long t1 = System.currentTimeMillis();
+            try {
+                log.info("get connection: BLOCKED for " + maxWait + " ...");
+                Connection con3 = pool.getConnection();
+                Assert.fail("expected pool timeout, got: " + con3.getCatalog() + " " + con3.isValid(0));
+            } catch (SQLException ex) {
+                if (!ex.getMessage().toLowerCase().contains("timeout")) {
+                    throw ex;
+                }
+                
+                long t2 = System.currentTimeMillis();
+                log.info("  caught: " + ex);
+                long timeout = t2 - t1;
+                log.info("timeout: " + timeout);
+                long dt = Math.abs(timeout - maxWait);
+                Assert.assertTrue("timeout", dt < 3L); // within 3 ms
+            }
+            
+            con1.close();
+            con2.close();
+            
+            t1 = System.currentTimeMillis();
+            con1 = pool.getConnection();
+            Assert.assertNotNull("connection 1", con1);
+            log.info("connection 1: " + con1.getCatalog() + " " + con1.isValid(0));
+            long t2 = System.currentTimeMillis();
+            long dt = t2 - t1;
+            Assert.assertTrue("connection returned to pool", dt < 3L);
+            
+        } catch (Exception t) {
+            log.error("unexpected exception", t);
+            Assert.fail("unexpected exception: " + t);
+        }
+    }
+}

--- a/cadc-inventory-util/src/main/java/org/opencadc/inventory/util/DBUtil.java
+++ b/cadc-inventory-util/src/main/java/org/opencadc/inventory/util/DBUtil.java
@@ -1,0 +1,163 @@
+/*
+************************************************************************
+*******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+**************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+*
+*  (c) 2020.                            (c) 2020.
+*  Government of Canada                 Gouvernement du Canada
+*  National Research Council            Conseil national de recherches
+*  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+*  All rights reserved                  Tous droits réservés
+*
+*  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+*  expressed, implied, or               énoncée, implicite ou légale,
+*  statutory, of any kind with          de quelque nature que ce
+*  respect to the software,             soit, concernant le logiciel,
+*  including without limitation         y compris sans restriction
+*  any warranty of merchantability      toute garantie de valeur
+*  or fitness for a particular          marchande ou de pertinence
+*  purpose. NRC shall not be            pour un usage particulier.
+*  liable in any event for any          Le CNRC ne pourra en aucun cas
+*  damages, whether direct or           être tenu responsable de tout
+*  indirect, special or general,        dommage, direct ou indirect,
+*  consequential or incidental,         particulier ou général,
+*  arising from the use of the          accessoire ou fortuit, résultant
+*  software.  Neither the name          de l'utilisation du logiciel. Ni
+*  of the National Research             le nom du Conseil National de
+*  Council of Canada nor the            Recherches du Canada ni les noms
+*  names of its contributors may        de ses  participants ne peuvent
+*  be used to endorse or promote        être utilisés pour approuver ou
+*  products derived from this           promouvoir les produits dérivés
+*  software without specific prior      de ce logiciel sans autorisation
+*  written permission.                  préalable et particulière
+*                                       par écrit.
+*
+*  This file is part of the             Ce fichier fait partie du projet
+*  OpenCADC project.                    OpenCADC.
+*
+*  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+*  you can redistribute it and/or       vous pouvez le redistribuer ou le
+*  modify it under the terms of         modifier suivant les termes de
+*  the GNU Affero General Public        la “GNU Affero General Public
+*  License as published by the          License” telle que publiée
+*  Free Software Foundation,            par la Free Software Foundation
+*  either version 3 of the              : soit la version 3 de cette
+*  License, or (at your option)         licence, soit (à votre gré)
+*  any later version.                   toute version ultérieure.
+*
+*  OpenCADC is distributed in the       OpenCADC est distribué
+*  hope that it will be useful,         dans l’espoir qu’il vous
+*  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+*  without even the implied             GARANTIE : sans même la garantie
+*  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+*  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+*  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+*  General Public License for           Générale Publique GNU Affero
+*  more details.                        pour plus de détails.
+*
+*  You should have received             Vous devriez avoir reçu une
+*  a copy of the GNU Affero             copie de la Licence Générale
+*  General Public License along         Publique GNU Affero avec
+*  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+*  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+*                                       <http://www.gnu.org/licenses/>.
+*
+************************************************************************
+*/
+
+package org.opencadc.inventory.util;
+
+import ca.nrc.cadc.db.ConnectionConfig;
+import ca.nrc.cadc.db.DBConfigException;
+import ca.nrc.cadc.db.StandaloneContextFactory;
+import javax.management.ObjectName;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.sql.DataSource;
+import org.apache.commons.dbcp2.ConnectionFactory;
+import org.apache.commons.dbcp2.DriverManagerConnectionFactory;
+import org.apache.commons.dbcp2.PoolableConnectionFactory;
+import org.apache.commons.dbcp2.PoolingDataSource;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.apache.log4j.Logger;
+
+/**
+ * Utility for applications to create and manage JDBC connections. This class extends
+ * <code>ca.nrc.cadc.db.DBUtil</code> to add some extra static methods for creating a
+ * connection pool. This code may be merged upstream into the parent class at some point.
+ * 
+ * @author pdowler
+ */
+public abstract class DBUtil extends ca.nrc.cadc.db.DBUtil {
+    private static final Logger log = Logger.getLogger(DBUtil.class);
+
+    private DBUtil() { 
+    }
+    
+    public static class PoolConfig {
+        private ConnectionConfig cc;
+
+        private int poolSize;
+        
+        private long maxWait;
+        
+        private String validationQuery;
+
+        public PoolConfig(ConnectionConfig cc, int poolSize, long maxWait, String validationQuery) {
+            this.cc = cc;
+            this.poolSize = poolSize;
+            this.maxWait = maxWait;
+            this.validationQuery = validationQuery;
+        }
+    }
+    
+    public static void createJNDIDataSource(String dataSourceName, PoolConfig config) throws NamingException {
+        log.debug("createJNDIDataSource: " + dataSourceName + " POOL START");
+        
+            
+        StandaloneContextFactory.initJNDI();
+
+        Context initContext = new InitialContext();
+        Context envContext = (Context) initContext.lookup(DEFAULT_JNDI_ENV_CONTEXT);
+        if (envContext == null) {
+            envContext = initContext.createSubcontext(DEFAULT_JNDI_ENV_CONTEXT);
+        }
+        log.debug("env: " + envContext);
+
+        DataSource dataSource = createPool(config);
+ 
+        envContext.bind(dataSourceName, dataSource);
+        log.debug("createJNDIDataSource: " + dataSourceName + " POOL DONE");
+    }
+    
+    private static DataSource createPool(PoolConfig config) {
+        try {
+            // load JDBC driver
+            Class.forName(config.cc.getDriver());
+        
+            ConnectionFactory connectionFactory = 
+                new DriverManagerConnectionFactory(config.cc.getURL(), config.cc.getUsername(), config.cc.getPassword());
+            
+            ObjectName jmxObjectName = null; // TODO? 
+            PoolableConnectionFactory poolableConnectionFactory = new PoolableConnectionFactory(connectionFactory, jmxObjectName);
+            poolableConnectionFactory.setValidationQuery(config.validationQuery);
+            
+            GenericObjectPool objectPool = new GenericObjectPool(poolableConnectionFactory);
+            objectPool.setMinIdle(config.poolSize);
+            objectPool.setMaxIdle(config.poolSize);
+            objectPool.setMaxTotal(config.poolSize);
+            objectPool.setTestOnBorrow(true);
+            objectPool.setTestOnCreate(true);
+            objectPool.setMaxWaitMillis(config.maxWait);
+            
+            PoolingDataSource dataSource = new PoolingDataSource(objectPool);
+            
+            return dataSource;
+        } catch (ClassNotFoundException ex) {
+            throw new DBConfigException("failed to load JDBC driver: " + config.cc.getDriver(), ex);
+        } catch (Exception ex) {
+            throw new DBConfigException("failed to init connection pool: " + config.cc.getURL(), ex);
+        }
+    }
+}

--- a/cadc-storage-adapter-fs/build.gradle
+++ b/cadc-storage-adapter-fs/build.gradle
@@ -17,7 +17,7 @@ apply from: '../opencadc.gradle'
 
 group = 'org.opencadc'
 
-version = '0.6.2'
+version = '0.6.3'
 
 dependencies {
     compile 'log4j:log4j:[1.2,)'

--- a/cadc-storage-adapter-fs/src/main/java/org/opencadc/inventory/storage/fs/OpaqueFileSystemStorageAdapter.java
+++ b/cadc-storage-adapter-fs/src/main/java/org/opencadc/inventory/storage/fs/OpaqueFileSystemStorageAdapter.java
@@ -255,11 +255,11 @@ public class OpaqueFileSystemStorageAdapter implements StorageAdapter {
      * @param storageLocation The storage location containing storageID and storageBucket.
      * @param dest The destination stream.
      * 
-     * @throws ResourceNotFoundException If the artifact could not be found.
-     * @throws ReadException If the storage system failed to stream.
-     * @throws WriteException If the client failed to stream.
-     * @throws StorageEngageException If the adapter failed to interact with storage.
-     * @throws TransientException If an unexpected, temporary exception occurred. 
+     * @throws ResourceNotFoundException If the artifact could not be found
+     * @throws ReadException If the storage system failed to stream
+     * @throws WriteException If the client failed to stream
+     * @throws StorageEngageException If the adapter failed to interact with storage
+     * @throws TransientException If an unexpected, temporary exception occurred
      */
     @Override
     public void get(StorageLocation storageLocation, OutputStream dest)
@@ -296,11 +296,12 @@ public class OpaqueFileSystemStorageAdapter implements StorageAdapter {
      * @param storageLocation the object to read
      * @param dest the output stream
      * @param byteRanges one or more byte ranges ordered to only seek forward
-     * @throws ResourceNotFoundException
-     * @throws ReadException
-     * @throws WriteException
-     * @throws StorageEngageException
-     * @throws TransientException 
+     * 
+     * @throws ResourceNotFoundException If the artifact could not be found
+     * @throws ReadException If the storage system failed to stream
+     * @throws WriteException If the client failed to stream
+     * @throws StorageEngageException If the adapter failed to interact with storage
+     * @throws TransientException If an unexpected, temporary exception occurred
      */
     public void get(StorageLocation storageLocation, OutputStream dest, SortedSet<ByteRange> byteRanges)
         throws ResourceNotFoundException, ReadException, WriteException, StorageEngageException, TransientException {

--- a/cadc-storage-adapter-fs/src/main/java/org/opencadc/inventory/storage/fs/OpaqueFileSystemStorageAdapter.java
+++ b/cadc-storage-adapter-fs/src/main/java/org/opencadc/inventory/storage/fs/OpaqueFileSystemStorageAdapter.java
@@ -467,13 +467,15 @@ public class OpaqueFileSystemStorageAdapter implements StorageAdapter {
                     // since filename is a UUID this is fatal
                     throw new RuntimeException("UUID collision on put: " + newArtifact.getArtifactURI() + " -> " + storageLocation);
                 }
+
+                // create this before committing the file so constraints applied
+                StorageMetadata metadata = new StorageMetadata(storageLocation, checksum, length);
                 
                 // to atomic copy into content directory
                 final Path result = Files.move(txnTarget, contentTarget, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
                 log.debug("moved file to : " + contentTarget);
                 txnTarget = null;
-
-                StorageMetadata metadata = new StorageMetadata(storageLocation, checksum, length);
+                
                 metadata.artifactURI = artifactURI;
                 metadata.contentLastModified = new Date(Files.getLastModifiedTime(result).toMillis());
                 return metadata;

--- a/cadc-storage-adapter-fs/src/main/java/org/opencadc/inventory/storage/fs/OpaqueIterator.java
+++ b/cadc-storage-adapter-fs/src/main/java/org/opencadc/inventory/storage/fs/OpaqueIterator.java
@@ -218,7 +218,7 @@ class OpaqueIterator implements Iterator<StorageMetadata> {
                 ret.artifactURI = new URI(aidAttr);
                 ret.contentLastModified = new Date(Files.getLastModifiedTime(p).toMillis());
                 return ret;
-            } catch (FileSystemException | URISyntaxException ex) {
+            } catch (FileSystemException | IllegalArgumentException | URISyntaxException ex) {
                 return new StorageMetadata(sloc); // missing attrs: invalid stored object
             }
         } catch (IOException ex) {

--- a/critwall/build.gradle
+++ b/critwall/build.gradle
@@ -10,11 +10,15 @@ repositories {
     mavenLocal()
 }
 
+apply from: '../opencadc.gradle'
+
 sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
 version = '0.1'
+
+mainClassName = 'org.opencadc.critwall.Main'
 
 dependencies {
     compile 'log4j:log4j:[1.2,)'
@@ -22,7 +26,7 @@ dependencies {
     compile 'org.opencadc:cadc-util:[1.3.4,2.0)'
     compile 'org.opencadc:cadc-inventory:[0.7,2.0)'
     compile 'org.opencadc:cadc-inventory-db:[0.9.1,1.0)'
-    compile 'org.opencadc:cadc-inventory-util:[0.1.0,1.0)'
+    compile 'org.opencadc:cadc-inventory-util:[0.1.1,1.0)'
     compile 'org.opencadc:cadc-registry:[1.5,2.0)'
     compile 'org.opencadc:cadc-vosi:[1.3.6,2.0)'
     compile 'org.opencadc:cadc-vos:[1.1.8,)'
@@ -31,9 +35,5 @@ dependencies {
     runtime 'org.opencadc:cadc-storage-adapter-swift:[0.4,)'
     
     testCompile 'junit:junit:[4.12,5.0)'
+    intTestCompile 'org.opencadc:cadc-storage-adapter-fs:[0.6,)'
 }
-
-mainClassName = 'org.opencadc.critwall.Main'
-
-apply from: '../opencadc.gradle'
-

--- a/critwall/src/intTest/java/org/opencadc/critwall/FileSyncJobTest.java
+++ b/critwall/src/intTest/java/org/opencadc/critwall/FileSyncJobTest.java
@@ -215,7 +215,7 @@ public class FileSyncJobTest {
             log.debug("putting test artifact to database");
             dao.put(artifactToUpdate);
 
-            FileSyncJob fsj = new FileSyncJob(artifactToUpdate, resourceID, sa, dao, anonSubject);
+            FileSyncJob fsj = new FileSyncJob(artifactToUpdate.getID(), resourceID, sa, dao, anonSubject);
             fsj.run();
 
             // check job succeeded by trying to get artifact by location
@@ -255,7 +255,7 @@ public class FileSyncJobTest {
             log.debug("putting test artifact to database");
             dao.put(artifactToUpdate);
 
-            FileSyncJob fsj = new FileSyncJob(artifactToUpdate, resourceID, sa, dao, anonSubject);
+            FileSyncJob fsj = new FileSyncJob(artifactToUpdate.getID(), resourceID, sa, dao, anonSubject);
             fsj.run();
 
             log.debug("finished run in failure test.");
@@ -291,7 +291,7 @@ public class FileSyncJobTest {
             log.debug("putting test artifact to database");
             dao.put(artifactToUpdate);
 
-            FileSyncJob fsj = new FileSyncJob(artifactToUpdate, resourceID, sa, dao, anonSubject);
+            FileSyncJob fsj = new FileSyncJob(artifactToUpdate.getID(), resourceID, sa, dao, anonSubject);
             fsj.run();
 
             log.debug("finished run in failure test.");
@@ -332,7 +332,7 @@ public class FileSyncJobTest {
             dao.put(artifactToUpdate);
             
 
-            FileSyncJob fsj = new FileSyncJob(artifactToUpdate, resourceID, sa, dao, anonSubject);
+            FileSyncJob fsj = new FileSyncJob(artifactToUpdate.getID(), resourceID, sa, dao, anonSubject);
             fsj.run();
 
             log.debug("successfully finished FileSyncJob run in test.");

--- a/critwall/src/intTest/java/org/opencadc/critwall/FileSyncTest.java
+++ b/critwall/src/intTest/java/org/opencadc/critwall/FileSyncTest.java
@@ -89,7 +89,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-
 import javax.security.auth.Subject;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;

--- a/critwall/src/main/java/org/opencadc/critwall/FileSync.java
+++ b/critwall/src/main/java/org/opencadc/critwall/FileSync.java
@@ -156,7 +156,7 @@ public class FileSync implements Runnable {
             this.jobArtifactDAO.setConfig(daoConfig);
             
             try {
-                String database = (String) daoConfig.get("database");
+                String database = null; // unused (String) daoConfig.get("database");
                 String schema = (String) daoConfig.get("schema");
                 DataSource ds = ca.nrc.cadc.db.DBUtil.findJNDIDataSource(fileSyncDS);
                 InitDatabase init = new InitDatabase(ds, database, schema);

--- a/critwall/src/main/java/org/opencadc/critwall/FileSyncJob.java
+++ b/critwall/src/main/java/org/opencadc/critwall/FileSyncJob.java
@@ -126,11 +126,11 @@ public class FileSyncJob implements Runnable {
     /**
      * Construct a job to sync the specified artifact.
      * 
-     * @param artifactID
-     * @param locatorServiceID
-     * @param storageAdapter
-     * @param artifactDAO
-     * @param subject 
+     * @param artifactID entity ID of artifact to sync
+     * @param locatorServiceID locator service to use
+     * @param storageAdapter back end storage
+     * @param artifactDAO database persistence
+     * @param subject caller with credentials for downloads
      */
     public FileSyncJob(UUID artifactID, URI locatorServiceID, StorageAdapter storageAdapter, ArtifactDAO artifactDAO, Subject subject) {
         InventoryUtil.assertNotNull(FileSyncJob.class, "artifactID", artifactID);

--- a/critwall/src/main/java/org/opencadc/critwall/Main.java
+++ b/critwall/src/main/java/org/opencadc/critwall/Main.java
@@ -199,8 +199,7 @@ public class Main {
             // populate/assign values to pass to FileSync
             Map<String, Object> daoConfig = new TreeMap<>();
             daoConfig.put("schema", schema);
-            daoConfig.put("database", dbUrl);
-
+            
             try {
                 daoConfig.put(SQLGENERATOR_CONFIG_KEY, Class.forName(generatorName));
             } catch (Exception ex) {

--- a/fenwick/build.gradle
+++ b/fenwick/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     compile 'log4j:log4j:[1.2,)'
     compile 'org.opencadc:cadc-storage-adapter:[0.3,1.0)'
     compile 'org.opencadc:cadc-util:[1.2,2.0)'
-    compile 'org.opencadc:cadc-inventory-db:[0.10,1.0)'
+    compile 'org.opencadc:cadc-inventory-db:[0.10.1,1.0)'
     compile 'org.opencadc:cadc-registry:[1.5,2.0)'
     compile 'org.opencadc:cadc-tap:[1.0.1,1.2)' // 1.2 upper bound is correct #reasons
 

--- a/fenwick/src/intTest/java/org/opencadc/fenwick/DeletedArtifactEventSyncTest.java
+++ b/fenwick/src/intTest/java/org/opencadc/fenwick/DeletedArtifactEventSyncTest.java
@@ -69,8 +69,6 @@
 
 package org.opencadc.fenwick;
 
-import static org.opencadc.fenwick.TestUtil.INVENTORY_DATABASE;
-import static org.opencadc.fenwick.TestUtil.INVENTORY_SCHEMA;
 import static org.opencadc.fenwick.TestUtil.LUSKAN_DATABASE;
 import static org.opencadc.fenwick.TestUtil.LUSKAN_SCHEMA;
 
@@ -99,7 +97,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.opencadc.inventory.DeletedArtifactEvent;
-import org.opencadc.inventory.db.DeletedEventDAO;
+import org.opencadc.inventory.db.DeletedArtifactEventDAO;
 import org.opencadc.inventory.db.SQLGenerator;
 import org.opencadc.tap.TapClient;
 import org.opencadc.tap.TapRowMapper;
@@ -116,7 +114,7 @@ public class DeletedArtifactEventSyncTest {
         Log4jInit.setLevel("org.opencadc.fenwick", Level.INFO);
     }
 
-    private final DeletedEventDAO<DeletedArtifactEvent> deletedEventDAO = new DeletedEventDAO<>();
+    private final DeletedArtifactEventDAO deletedEventDAO = new DeletedArtifactEventDAO();
 
     public DeletedArtifactEventSyncTest() throws Exception {
         final DBConfig dbConfig = new DBConfig();

--- a/fenwick/src/intTest/java/org/opencadc/fenwick/DeletedStorageLocationEventSyncTest.java
+++ b/fenwick/src/intTest/java/org/opencadc/fenwick/DeletedStorageLocationEventSyncTest.java
@@ -94,7 +94,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.opencadc.inventory.DeletedStorageLocationEvent;
-import org.opencadc.inventory.db.DeletedEventDAO;
+import org.opencadc.inventory.db.DeletedStorageLocationEventDAO;
 import org.opencadc.inventory.db.SQLGenerator;
 import org.opencadc.tap.TapClient;
 import org.opencadc.tap.TapRowMapper;
@@ -111,7 +111,7 @@ public class DeletedStorageLocationEventSyncTest {
         Log4jInit.setLevel("org.opencadc.fenwick", Level.INFO);
     }
 
-    private final DeletedEventDAO<DeletedStorageLocationEvent> deletedEventDAO = new DeletedEventDAO<>();
+    private final DeletedStorageLocationEventDAO deletedEventDAO = new DeletedStorageLocationEventDAO();
 
     public DeletedStorageLocationEventSyncTest() throws Exception {
         final DBConfig dbConfig = new DBConfig();

--- a/fenwick/src/intTest/java/org/opencadc/fenwick/InventoryEnvironment.java
+++ b/fenwick/src/intTest/java/org/opencadc/fenwick/InventoryEnvironment.java
@@ -71,14 +71,11 @@ package org.opencadc.fenwick;
 import ca.nrc.cadc.db.ConnectionConfig;
 import ca.nrc.cadc.db.DBConfig;
 import ca.nrc.cadc.db.DBUtil;
-
 import java.util.Map;
 import java.util.TreeMap;
-
-import org.apache.log4j.Logger;
-import org.opencadc.inventory.DeletedStorageLocationEvent;
 import org.opencadc.inventory.db.ArtifactDAO;
-import org.opencadc.inventory.db.DeletedEventDAO;
+import org.opencadc.inventory.db.DeletedArtifactEventDAO;
+import org.opencadc.inventory.db.DeletedStorageLocationEventDAO;
 import org.opencadc.inventory.db.HarvestStateDAO;
 import org.opencadc.inventory.db.SQLGenerator;
 import org.opencadc.inventory.db.StorageSiteDAO;
@@ -90,8 +87,8 @@ import org.springframework.jdbc.core.JdbcTemplate;
 public class InventoryEnvironment {
     final StorageSiteDAO storageSiteDAO = new StorageSiteDAO();
     final ArtifactDAO artifactDAO = new ArtifactDAO();
-    final TestUtil.DeletedArtifactEventDAO deletedArtifactEventDAO = new TestUtil.DeletedArtifactEventDAO();
-    final TestUtil.DeletedStorageLocationEventDAO deletedStorageLocationEventDAO = new TestUtil.DeletedStorageLocationEventDAO();
+    final DeletedArtifactEventDAO deletedArtifactEventDAO = new DeletedArtifactEventDAO();
+    final DeletedStorageLocationEventDAO deletedStorageLocationEventDAO = new DeletedStorageLocationEventDAO();
     final HarvestStateDAO harvestStateDAO = new HarvestStateDAO();
     final Map<String, Object> daoConfig = new TreeMap<>();
     final String jndiPath = "jdbc/InventoryEnvironment";

--- a/fenwick/src/intTest/java/org/opencadc/fenwick/LuskanEnvironment.java
+++ b/fenwick/src/intTest/java/org/opencadc/fenwick/LuskanEnvironment.java
@@ -76,8 +76,8 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import org.apache.log4j.Logger;
-import org.opencadc.fenwick.TestUtil.DeletedArtifactEventDAO;
-import org.opencadc.fenwick.TestUtil.DeletedStorageLocationEventDAO;
+import org.opencadc.inventory.db.DeletedArtifactEventDAO;
+import org.opencadc.inventory.db.DeletedStorageLocationEventDAO;
 import org.opencadc.inventory.db.ArtifactDAO;
 import org.opencadc.inventory.db.SQLGenerator;
 import org.opencadc.inventory.db.StorageSiteDAO;

--- a/fenwick/src/main/java/org/opencadc/fenwick/InventoryHarvester.java
+++ b/fenwick/src/main/java/org/opencadc/fenwick/InventoryHarvester.java
@@ -79,7 +79,6 @@ import ca.nrc.cadc.reg.Capabilities;
 import ca.nrc.cadc.reg.Capability;
 import ca.nrc.cadc.reg.Standards;
 import ca.nrc.cadc.reg.client.RegistryClient;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -92,7 +91,6 @@ import java.security.cert.CertificateExpiredException;
 import java.text.DateFormat;
 import java.util.Calendar;
 import java.util.Map;
-
 import javax.security.auth.Subject;
 import javax.sql.DataSource;
 import org.apache.log4j.Logger;
@@ -103,7 +101,8 @@ import org.opencadc.inventory.InventoryUtil;
 import org.opencadc.inventory.SiteLocation;
 import org.opencadc.inventory.StorageSite;
 import org.opencadc.inventory.db.ArtifactDAO;
-import org.opencadc.inventory.db.DeletedEventDAO;
+import org.opencadc.inventory.db.DeletedArtifactEventDAO;
+import org.opencadc.inventory.db.EntityNotFoundException;
 import org.opencadc.inventory.db.HarvestState;
 import org.opencadc.inventory.db.HarvestStateDAO;
 import org.opencadc.inventory.db.StorageSiteDAO;
@@ -282,21 +281,22 @@ public class InventoryHarvester implements Runnable {
      */
     void doit() throws ResourceNotFoundException, IOException, IllegalStateException, TransientException,
                        InterruptedException, NoSuchAlgorithmException, CertificateException {
+        final TapClient tapClient = new TapClient<>(this.resourceID);
+        
         final StorageSite storageSite;
-
         if (trackSiteLocations) {
-            final TapClient<StorageSite> storageSiteTapClient = new TapClient<>(this.resourceID);
+            
             final StorageSiteDAO storageSiteDAO = new StorageSiteDAO(this.artifactDAO);
-            final StorageSiteSync storageSiteSync = new StorageSiteSync(storageSiteTapClient, storageSiteDAO);
+            final StorageSiteSync storageSiteSync = new StorageSiteSync(tapClient, storageSiteDAO);
             storageSite = storageSiteSync.doit();
 
-            syncDeletedStorageLocationEvents(storageSite);
+            syncDeletedStorageLocationEvents(tapClient, storageSite);
         } else {
             storageSite = null;
         }
 
-        syncDeletedArtifactEvents();
-        syncArtifacts(storageSite);
+        syncDeletedArtifactEvents(tapClient);
+        syncArtifacts(tapClient, storageSite);
     }
 
     /**
@@ -309,23 +309,17 @@ public class InventoryHarvester implements Runnable {
      * @throws TransientException        temporary failure of TAP service: same call could work in future
      * @throws InterruptedException      thread interrupted
      */
-    private void syncDeletedStorageLocationEvents(final StorageSite storageSite)
+    private void syncDeletedStorageLocationEvents(final TapClient tapClient, final StorageSite storageSite)
             throws ResourceNotFoundException, IOException, IllegalStateException, TransientException,
                    InterruptedException, CertificateException {
-        final HarvestState existingHarvestState = this.harvestStateDAO.get(DeletedStorageLocationEvent.class.getName(),
+        final HarvestState harvestState = this.harvestStateDAO.get(DeletedStorageLocationEvent.class.getName(),
                                                                            this.resourceID);
-        final HarvestState harvestState = (existingHarvestState == null)
-                                          ? new HarvestState(DeletedStorageLocationEvent.class.getName(),
-                                                             this.resourceID)
-                                          : existingHarvestState;
 
         DateFormat df = DateUtil.getDateFormat(DateUtil.IVOA_DATE_FORMAT, DateUtil.UTC);
 
         verifySubject();
-        final TapClient<DeletedStorageLocationEvent> deletedStorageLocationEventTapClient =
-                new TapClient<>(this.resourceID);
-        final DeletedStorageLocationEventSync deletedStorageLocationEventSync =
-                new DeletedStorageLocationEventSync(deletedStorageLocationEventTapClient);
+        
+        final DeletedStorageLocationEventSync deletedStorageLocationEventSync = new DeletedStorageLocationEventSync(tapClient);
         deletedStorageLocationEventSync.startTime = harvestState.curLastModified;
 
         final TransactionManager transactionManager = artifactDAO.getTransactionManager();
@@ -350,9 +344,14 @@ public class InventoryHarvester implements Runnable {
                     continue; // ugh
                 }
 
+                Artifact artifact = this.artifactDAO.get(deletedStorageLocationEvent.getID());
+
                 transactionManager.startTransaction();
-                final Artifact artifact = this.artifactDAO.get(deletedStorageLocationEvent.getID());
+
                 if (artifact != null) {
+                    artifactDAO.lock(artifact);
+                    artifact = this.artifactDAO.get(deletedStorageLocationEvent.getID());
+                    
                     final SiteLocation siteLocation = new SiteLocation(storageSite.getID());
                     // TODO: this message could also log the artifact and site that was removed
                     log.info("PUT: DeletedStorageLocationEvent " + deletedStorageLocationEvent.getID()
@@ -360,11 +359,16 @@ public class InventoryHarvester implements Runnable {
                     artifactDAO.removeSiteLocation(artifact, siteLocation);
                     harvestState.curLastModified = deletedStorageLocationEvent.getLastModified();
                     harvestStateDAO.put(harvestState);
-                } else {
-                    log.warn("Artifact " + deletedStorageLocationEvent.getID() + " does not exist locally.");
                 }
+                
                 transactionManager.commitTransaction();
 
+            }
+        } catch (EntityNotFoundException ex) {
+            try {
+                transactionManager.rollbackTransaction();
+            } catch (Exception tex) {
+                log.error("failed to rollback txn after lock encountered " + ex, tex);
             }
         } catch (Exception exception) {
             if (transactionManager.isOpen()) {
@@ -386,23 +390,16 @@ public class InventoryHarvester implements Runnable {
      * @throws TransientException        temporary failure of TAP service: same call could work in future
      * @throws InterruptedException      thread interrupted
      */
-    private void syncDeletedArtifactEvents() throws ResourceNotFoundException, IOException, IllegalStateException,
+    private void syncDeletedArtifactEvents(final TapClient tapClient) throws ResourceNotFoundException, IOException, IllegalStateException,
                                                     TransientException, InterruptedException, CertificateException {
-        final HarvestState existingHarvestState = this.harvestStateDAO.get(DeletedArtifactEvent.class.getName(),
+        final HarvestState harvestState = this.harvestStateDAO.get(DeletedArtifactEvent.class.getName(),
                                                                            this.resourceID);
-        final HarvestState harvestState = (existingHarvestState == null)
-                                                  ? new HarvestState(DeletedArtifactEvent.class.getName(),
-                                                                     this.resourceID)
-                                                  : existingHarvestState;
 
         DateFormat df = DateUtil.getDateFormat(DateUtil.IVOA_DATE_FORMAT, DateUtil.UTC);
 
         verifySubject();
-        final TapClient<DeletedArtifactEvent> deletedArtifactEventTapClientTapClient = new TapClient<>(this.resourceID);
-        final DeletedArtifactEventSync deletedArtifactEventSync =
-                new DeletedArtifactEventSync(deletedArtifactEventTapClientTapClient);
-        final DeletedEventDAO<DeletedArtifactEvent> deletedArtifactEventDeletedEventDAO =
-                new DeletedEventDAO<>(this.artifactDAO);
+        final DeletedArtifactEventSync deletedArtifactEventSync = new DeletedArtifactEventSync(tapClient);
+        final DeletedArtifactEventDAO deletedArtifactEventDeletedEventDAO = new DeletedArtifactEventDAO(this.artifactDAO);
         deletedArtifactEventSync.startTime = harvestState.curLastModified;
 
         final TransactionManager transactionManager = artifactDAO.getTransactionManager();
@@ -427,6 +424,7 @@ public class InventoryHarvester implements Runnable {
                 }
                 
                 transactionManager.startTransaction();
+                // no need to acquire lock on artifact
                 log.info("PUT: DeletedArtifactEvent " + deletedArtifactEvent.getID() + " " + df.format(deletedArtifactEvent.getLastModified()));
                 deletedArtifactEventDeletedEventDAO.put(deletedArtifactEvent);
                 artifactDAO.delete(deletedArtifactEvent.getID());
@@ -457,28 +455,24 @@ public class InventoryHarvester implements Runnable {
      * @throws TransientException        temporary failure of TAP service: same call could work in future
      * @throws InterruptedException      thread interrupted
      */
-    private void syncArtifacts(final StorageSite storageSite)
+    private void syncArtifacts(final TapClient tapClient, final StorageSite storageSite)
             throws ResourceNotFoundException, IOException, IllegalStateException, NoSuchAlgorithmException,
                    InterruptedException, TransientException, CertificateException {
         final MessageDigest messageDigest = MessageDigest.getInstance("MD5");
         DateFormat df = DateUtil.getDateFormat(DateUtil.IVOA_DATE_FORMAT, DateUtil.UTC);
 
         verifySubject();
-        final TapClient<Artifact> artifactTapClient = new TapClient<>(this.resourceID);
 
-        final HarvestState existingHarvestState = this.harvestStateDAO.get(Artifact.class.getName(), this.resourceID);
-        final HarvestState harvestState = (existingHarvestState == null)
-                                          ? new HarvestState(Artifact.class.getName(), this.resourceID)
-                                          : existingHarvestState;
+        final HarvestState harvestState = this.harvestStateDAO.get(Artifact.class.getName(), this.resourceID);
 
-        final ArtifactSync artifactSync = new ArtifactSync(artifactTapClient, harvestState.curLastModified);
-
+        final ArtifactSync artifactSync = new ArtifactSync(tapClient, harvestState.curLastModified);
+        artifactSync.includeClause = this.selector.getConstraint();
+        
         final TransactionManager transactionManager = artifactDAO.getTransactionManager();
 
         try {
-            // The constraint can be null as is the case for the AllArtifacts selector.
-            artifactSync.includeClause = this.selector.getConstraint();
-
+            DeletedArtifactEventDAO daeDAO = new DeletedArtifactEventDAO(artifactDAO);
+            
             String start = null;
             if (harvestState.curLastModified != null) {
                 start = df.format(harvestState.curLastModified);
@@ -494,7 +488,9 @@ public class InventoryHarvester implements Runnable {
                             && artifact.getLastModified().equals(harvestState.curLastModified)) {
                         log.debug("SKIP: previously processed: " + artifact.getID() + " " + artifact.getURI());
                         first = false;
-                        continue; // ugh
+                        // ugh but the skip is comprehensible: have to do this inside the loop when using
+                        // try-with-resources
+                        continue;
                     }
 
                     log.debug("START: Process Artifact " + artifact.getID() + " " + artifact.getURI());
@@ -505,16 +501,30 @@ public class InventoryHarvester implements Runnable {
                                 + " provided=" + artifact.getMetaChecksum() + " actual=" + computedChecksum);
                     }
 
-                    // TODO: acquire update lock on current artifact and get it again, move startTransaction
-                    Artifact currentArtifact = artifactDAO.get(artifact.getID());
-
                     transactionManager.startTransaction();
-
+                    Artifact currentArtifact = null;
+                    try {
+                        artifactDAO.lock(artifact);
+                        currentArtifact = artifactDAO.get(artifact.getID());
+                    } catch (EntityNotFoundException ex) {
+                        currentArtifact = null;
+                    }
+                    
+                    if (currentArtifact == null) {
+                        // check if it was already deleted (sync from stale site)
+                        DeletedArtifactEvent ev = daeDAO.get(artifact.getID());
+                        if (ev != null) {
+                            log.info("SKIP: stale artifact " + artifact.getID() + " " + artifact.getURI() + " " + df.format(artifact.getLastModified()));
+                            continue;
+                        }
+                    }
+                    
                     log.info("PUT: artifact " + artifact.getID() + " " + artifact.getURI() + " " + df.format(artifact.getLastModified()));
                     if (storageSite != null && currentArtifact != null && artifact.getMetaChecksum().equals(currentArtifact.getMetaChecksum())) {
                         // only adding a SiteLocation
                         artifactDAO.addSiteLocation(currentArtifact, new SiteLocation(storageSite.getID()));
                     } else {
+                        // new artifact || updated metadata
                         if (storageSite != null) {
                             // trackSiteLocations: merge SiteLocation(s)
                             artifact.siteLocations.add(new SiteLocation(storageSite.getID()));
@@ -527,7 +537,6 @@ public class InventoryHarvester implements Runnable {
                                 artifact.storageLocation = currentArtifact.storageLocation;
                             }
                         }
-
                         artifactDAO.put(artifact);
                     }
 

--- a/fenwick/src/test/java/org/opencadc/fenwick/IncludeArtifactsTest.java
+++ b/fenwick/src/test/java/org/opencadc/fenwick/IncludeArtifactsTest.java
@@ -1,4 +1,3 @@
-
 /*
  ************************************************************************
  *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
@@ -70,18 +69,18 @@
 package org.opencadc.fenwick;
 
 import ca.nrc.cadc.util.Log4jInit;
-
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
-
 import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Test;
 
 
 public class IncludeArtifactsTest {
-
+    private static final Logger log = Logger.getLogger(IncludeArtifactsTest.class);
+    
     static {
         Log4jInit.setLevel("org.opencadc.fenwick", Level.DEBUG);
     }
@@ -179,6 +178,42 @@ public class IncludeArtifactsTest {
             }
         } finally {
             System.setProperty("user.home", currUserHome);
+        }
+    }
+    
+    @Test
+    public void testMissingConfigFile() throws Exception {
+        final String oldSetting = System.getProperty("user.home");
+        try {
+            final Path tempLocation = Files.createTempDirectory(IncludeArtifactsTest.class.getName());
+            System.setProperty("user.home", tempLocation.toString());
+            log.debug("Now looking for includes in " + System.getProperty("user.home") + "/config");
+            Files.createDirectories(new File(System.getProperty("user.home") + "/config").toPath());
+            
+            IncludeArtifacts o = new IncludeArtifacts();
+            Assert.fail("expected IllegalStateException, got: " + o);
+        } catch (IllegalStateException expected) {
+            log.info("caught expected: " + expected);
+        } finally {
+            System.setProperty("user.home", oldSetting);
+        }
+    }
+    
+    @Test
+    public void testMissingConfigDir() throws Exception {
+        final String oldSetting = System.getProperty("user.home");
+        try {
+            final Path tempLocation = Files.createTempDirectory(IncludeArtifactsTest.class.getName());
+            System.setProperty("user.home", tempLocation.toString());
+            log.debug("Now looking for includes in non-existent " + System.getProperty("user.home") + "/config");
+            Files.createDirectories(new File(System.getProperty("user.home")).toPath());
+            
+            IncludeArtifacts o = new IncludeArtifacts();
+            Assert.fail("expected IllegalStateException, got: " + o);
+        } catch (IllegalStateException expected) {
+            log.info("caught expected: " + expected);
+        } finally {
+            System.setProperty("user.home", oldSetting);
         }
     }
 }

--- a/minoc/build.gradle
+++ b/minoc/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     compile 'org.opencadc:cadc-cdp:[1.0,)'
     compile 'org.opencadc:cadc-gms:[1.0.0,)'
     compile 'org.opencadc:cadc-inventory:[0.7,)'
-    compile 'org.opencadc:cadc-inventory-db:[0.7,)'
+    compile 'org.opencadc:cadc-inventory-db:[0.10.1,)'
     compile 'org.opencadc:cadc-inventory-server:[0.1.1,)'
     compile 'org.opencadc:cadc-storage-adapter:[0.2,)'
     compile 'org.opencadc:cadc-permissions:[0.3,)'

--- a/minoc/src/main/java/org/opencadc/minoc/DeleteAction.java
+++ b/minoc/src/main/java/org/opencadc/minoc/DeleteAction.java
@@ -72,7 +72,7 @@ import ca.nrc.cadc.net.ResourceNotFoundException;
 import org.apache.log4j.Logger;
 import org.opencadc.inventory.Artifact;
 import org.opencadc.inventory.DeletedArtifactEvent;
-import org.opencadc.inventory.db.DeletedEventDAO;
+import org.opencadc.inventory.db.DeletedArtifactEventDAO;
 import org.opencadc.inventory.db.EntityNotFoundException;
 import org.opencadc.inventory.db.ObsoleteStorageLocation;
 import org.opencadc.inventory.db.ObsoleteStorageLocationDAO;
@@ -107,7 +107,7 @@ public class DeleteAction extends ArtifactAction {
             throw new ResourceNotFoundException("not found: " + artifactURI);
         }
         
-        DeletedEventDAO eventDAO = new DeletedEventDAO(artifactDAO);
+        DeletedArtifactEventDAO eventDAO = new DeletedArtifactEventDAO(artifactDAO);
         TransactionManager txnMgr = artifactDAO.getTransactionManager();
         
         try {
@@ -131,8 +131,8 @@ public class DeleteAction extends ArtifactAction {
             }
             
             DeletedArtifactEvent deletedArtifact = new DeletedArtifactEvent(existing.getID());
-            artifactDAO.delete(existing.getID());
             eventDAO.put(deletedArtifact);
+            artifactDAO.delete(existing.getID());
             ObsoleteStorageLocation dsl = null;
             ObsoleteStorageLocationDAO locDAO = new ObsoleteStorageLocationDAO(artifactDAO);
             if (existing.storageLocation != null) {

--- a/minoc/src/main/java/org/opencadc/minoc/PutAction.java
+++ b/minoc/src/main/java/org/opencadc/minoc/PutAction.java
@@ -254,10 +254,11 @@ public class PutAction extends ArtifactAction {
             if (existing != null) {
                 DeletedEventDAO eventDAO = new DeletedEventDAO(artifactDAO);
                 DeletedArtifactEvent deletedArtifact = new DeletedArtifactEvent(existing.getID());
-                artifactDAO.delete(existing.getID());
-                profiler.checkpoint("artifactDAO.delete.ok");
                 eventDAO.put(deletedArtifact);
                 profiler.checkpoint("eventDAO.put.ok");
+                
+                artifactDAO.delete(existing.getID());
+                profiler.checkpoint("artifactDAO.delete.ok");
             }
             
             artifactDAO.put(artifact);

--- a/minoc/src/main/java/org/opencadc/minoc/PutAction.java
+++ b/minoc/src/main/java/org/opencadc/minoc/PutAction.java
@@ -86,7 +86,7 @@ import java.util.Date;
 import org.apache.log4j.Logger;
 import org.opencadc.inventory.Artifact;
 import org.opencadc.inventory.DeletedArtifactEvent;
-import org.opencadc.inventory.db.DeletedEventDAO;
+import org.opencadc.inventory.db.DeletedArtifactEventDAO;
 import org.opencadc.inventory.db.EntityNotFoundException;
 import org.opencadc.inventory.db.ObsoleteStorageLocation;
 import org.opencadc.inventory.db.ObsoleteStorageLocationDAO;
@@ -252,7 +252,7 @@ public class PutAction extends ArtifactAction {
             
             ObsoleteStorageLocation newOSL = null;
             if (existing != null) {
-                DeletedEventDAO eventDAO = new DeletedEventDAO(artifactDAO);
+                DeletedArtifactEventDAO eventDAO = new DeletedArtifactEventDAO(artifactDAO);
                 DeletedArtifactEvent deletedArtifact = new DeletedArtifactEvent(existing.getID());
                 eventDAO.put(deletedArtifact);
                 profiler.checkpoint("eventDAO.put.ok");

--- a/raven/src/intTest/java/org/opencadc/raven/RavenTest.java
+++ b/raven/src/intTest/java/org/opencadc/raven/RavenTest.java
@@ -168,7 +168,7 @@ public abstract class RavenTest {
         String response = post.getResponseBody();
         TransferReader reader = new TransferReader();
         Transfer t = reader.read(response,  null);
-        log.info("Response transfer: " + t);
+        log.debug("Response transfer: " + t);
         return t;
     }
 

--- a/tantar/build.gradle
+++ b/tantar/build.gradle
@@ -18,7 +18,7 @@ version = '0.1'
 
 dependencies {
     compile 'log4j:log4j:[1.2,)'
-    compile 'org.opencadc:cadc-inventory-db:[0.9.1,1.0)'
+    compile 'org.opencadc:cadc-inventory-db:[0.10.1,1.0)'
     compile 'org.opencadc:cadc-log:[1.1.2,2.0)'
     compile 'org.opencadc:cadc-util:[1.3,2.0)'
     compile 'org.opencadc:cadc-inventory-util:[0.1.0,1.0)'

--- a/tantar/src/main/java/org/opencadc/tantar/ValidateEventListener.java
+++ b/tantar/src/main/java/org/opencadc/tantar/ValidateEventListener.java
@@ -107,7 +107,7 @@ public interface ValidateEventListener extends EventListener {
      * @param artifact The base artifact.  This MUST have a Storage Location.
      * @throws Exception Anything IO/Thread related.
      */
-    void markAsNew(final Artifact artifact) throws Exception;
+    void clearStorageLocation(final Artifact artifact) throws Exception;
 
     /**
      * Replace the given Artifact with a new one created from the given StorageMetadata instance.

--- a/tantar/src/main/java/org/opencadc/tantar/policy/InventoryIsAlwaysRight.java
+++ b/tantar/src/main/java/org/opencadc/tantar/policy/InventoryIsAlwaysRight.java
@@ -97,12 +97,12 @@ public class InventoryIsAlwaysRight extends ResolutionPolicy {
             // either.
             reporter.report("Resetting Artifact " + artifact.storageLocation + " as per policy.");
 
-            validateEventListener.markAsNew(artifact);
+            validateEventListener.clearStorageLocation(artifact);
         } else if (!storageMetadata.isValid()) {
             reporter.report("Invalid Storage Metadata (" + storageMetadata.getStorageLocation() + ").  "
                             + "Replacing as per policy.");
             validateEventListener.delete(storageMetadata);
-            validateEventListener.markAsNew(artifact);
+            validateEventListener.clearStorageLocation(artifact);
         } else if (artifact == null) {
             reporter.report("Removing Unknown File " + storageMetadata.getStorageLocation() + " as per policy.");
 
@@ -114,7 +114,7 @@ public class InventoryIsAlwaysRight extends ResolutionPolicy {
                 reporter.report("Replacing File " + storageMetadata.getStorageLocation() + " as per policy.");
 
                 validateEventListener.delete(storageMetadata);
-                validateEventListener.markAsNew(artifact);
+                validateEventListener.clearStorageLocation(artifact);
             } else {
                 reporter.report("Artifact " + artifact.storageLocation + " is valid as per policy.");
             }

--- a/tantar/src/main/java/org/opencadc/tantar/policy/InventoryIsAlwaysRight.java
+++ b/tantar/src/main/java/org/opencadc/tantar/policy/InventoryIsAlwaysRight.java
@@ -90,6 +90,10 @@ public class InventoryIsAlwaysRight extends ResolutionPolicy {
      */
     @Override
     public void resolve(final Artifact artifact, final StorageMetadata storageMetadata) throws Exception {
+        if (artifact == null && storageMetadata == null) {
+            throw new RuntimeException("BUG: both args to resolve are null");
+        }
+        
         if (storageMetadata == null) {
             // Scenario when an Entity exists in the inventory database but the file is not in Storage.  This can
             // happen in the case where all files are managed by the inventory but an intervention outside of the
@@ -98,15 +102,16 @@ public class InventoryIsAlwaysRight extends ResolutionPolicy {
             reporter.report("Resetting Artifact " + artifact.storageLocation + " as per policy.");
 
             validateEventListener.clearStorageLocation(artifact);
-        } else if (!storageMetadata.isValid()) {
-            reporter.report("Invalid Storage Metadata (" + storageMetadata.getStorageLocation() + ").  "
-                            + "Replacing as per policy.");
-            validateEventListener.delete(storageMetadata);
-            validateEventListener.clearStorageLocation(artifact);
         } else if (artifact == null) {
             reporter.report("Removing Unknown File " + storageMetadata.getStorageLocation() + " as per policy.");
 
             validateEventListener.delete(storageMetadata);
+        } else if (!storageMetadata.isValid()) {
+            reporter.report("Invalid Storage Metadata (" + storageMetadata.getStorageLocation() + ").  "
+                            + "Replacing as per policy.");
+
+            validateEventListener.delete(storageMetadata);
+            validateEventListener.clearStorageLocation(artifact);
         } else {
             // Check metadata for discrepancies.
             if (haveDifferentStructure(artifact, storageMetadata)) {

--- a/tantar/src/main/java/org/opencadc/tantar/policy/StorageIsAlwaysRight.java
+++ b/tantar/src/main/java/org/opencadc/tantar/policy/StorageIsAlwaysRight.java
@@ -90,7 +90,15 @@ public class StorageIsAlwaysRight extends ResolutionPolicy {
      */
     @Override
     public void resolve(final Artifact artifact, final StorageMetadata storageMetadata) throws Exception {
-        if (artifact == null) {
+        if (artifact == null && storageMetadata == null) {
+            throw new RuntimeException("BUG: both args to resolve are null");
+        }
+        
+        if (storageMetadata == null) {
+            reporter.report("Removing Unknown Artifact " + artifact.storageLocation + " as per policy.");
+
+            validateEventListener.delete(artifact);
+        } else if (artifact == null) {
             if (storageMetadata.isValid()) {
                 // The Inventory has a file that does not exist in storage.  This is most unusual.
                 reporter.report("Adding Artifact " + storageMetadata.getStorageLocation() + " as per policy.");
@@ -101,23 +109,17 @@ public class StorageIsAlwaysRight extends ResolutionPolicy {
                 reporter.report("Corrupt or invalid Storage Metadata (" + storageMetadata.getStorageLocation()
                                 + ").  Skipping as per policy.");
             }
-        } else if (storageMetadata == null) {
-            reporter.report("Removing Unknown Artifact " + artifact.storageLocation + " as per policy.");
-            validateEventListener.delete(artifact);
+        } else if (!storageMetadata.isValid()) {
+            // If storage is always right, but it has no metadata, then leave it for someone to manually fix.
+            reporter.report("Invalid Storage Metadata (" + storageMetadata.getStorageLocation()
+                            + ").  Skipping as per policy.");
         } else {
             // Check metadata for discrepancies.
             if (haveDifferentStructure(artifact, storageMetadata)) {
-                // The metadata differs, but for valid reasons (update).
-                if (storageMetadata.isValid()) {
-                    // Then prefer the Storage Metadata.
-                    reporter.report("Replacing Artifact " + artifact.storageLocation + " as per policy.");
+                // Then prefer the Storage Metadata.
+                reporter.report("Replacing Artifact " + artifact.storageLocation + " as per policy.");
 
-                    validateEventListener.replaceArtifact(artifact, storageMetadata);
-                } else {
-                    // If storage is always right, but it has no metadata, then leave it for someone to manually fix.
-                    reporter.report("Invalid Storage Metadata (" + storageMetadata.getStorageLocation()
-                                    + ").  Skipping as per policy.");
-                }
+                validateEventListener.replaceArtifact(artifact, storageMetadata);
             } else {
                 reporter.report("Storage Metadata " + storageMetadata.getStorageLocation()
                                 + " is valid as per policy.");

--- a/tantar/src/test/java/org/opencadc/tantar/TestEventListener.java
+++ b/tantar/src/test/java/org/opencadc/tantar/TestEventListener.java
@@ -97,7 +97,7 @@ public class TestEventListener implements ValidateEventListener {
     }
 
     @Override
-    public void markAsNew(Artifact artifact) throws Exception {
+    public void clearStorageLocation(Artifact artifact) throws Exception {
         resetArtifactCalled = true;
     }
 

--- a/tantar/src/test/java/org/opencadc/tantar/policy/AbstractResolutionPolicyTest.java
+++ b/tantar/src/test/java/org/opencadc/tantar/policy/AbstractResolutionPolicyTest.java
@@ -140,7 +140,7 @@ public class AbstractResolutionPolicyTest<T extends ResolutionPolicy> {
         }
 
         @Override
-        public void markAsNew(Artifact artifact) throws Exception {
+        public void clearStorageLocation(Artifact artifact) throws Exception {
             resetArtifactCalled = true;
         }
 

--- a/tantar/src/test/java/org/opencadc/tantar/policy/InventoryIsAlwaysRightTest.java
+++ b/tantar/src/test/java/org/opencadc/tantar/policy/InventoryIsAlwaysRightTest.java
@@ -164,7 +164,7 @@ public class InventoryIsAlwaysRightTest extends AbstractResolutionPolicyTest<Inv
                                   "Invalid Storage Metadata (StorageLocation[s3:989877]).  "
                                   + "Replacing as per policy.");
 
-        Assert.assertTrue("Should only have called deleteStorageMetadata and markAsNew.",
+        Assert.assertTrue("Should only have called deleteStorageMetadata and clearStorageLocation.",
                           !testEventListener.deleteArtifactCalled
                           && !testEventListener.addArtifactCalled
                           && testEventListener.resetArtifactCalled


### PR DESCRIPTION
re-sequence some database operations
prototype connection pool for use in critwall; made AbstractDAO thread-safe (
critwall and tantar now run InitDatabase on startup (fix critwall bug setting database dao config prop)
fix some logic to prevent NPE in tantar policies
fix opaque filesystem adapter to handle invalid stored objects in put and iterator

