### PR TITLE
CADC-8679 update minoc to use Digest HTTP header instead of Content-MD5

### DIFF
--- a/minoc/build.gradle
+++ b/minoc/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     compile 'org.opencadc:cadc-log:[1.0,)'
     compile 'org.opencadc:cadc-registry:[1.5.9,)'
     compile 'org.opencadc:cadc-vosi:[1.3.7,)'
-    compile 'org.opencadc:cadc-rest:[1.2.18,)'
+    compile 'org.opencadc:cadc-rest:[1.2.20,)'
     compile 'org.opencadc:cadc-cdp:[1.0,)'
     compile 'org.opencadc:cadc-data-ops-fits:[0.1.1,)'
     compile 'org.opencadc:cadc-gms:[1.0.0,)'

--- a/minoc/build.gradle
+++ b/minoc/build.gradle
@@ -25,7 +25,7 @@ war {
 
 dependencies {
     compile 'log4j:log4j:[1.2,)'
-    compile 'org.opencadc:cadc-util:[1.3.14,)'
+    compile 'org.opencadc:cadc-util:[1.3.16,)'
     compile 'org.opencadc:cadc-log:[1.0,)'
     compile 'org.opencadc:cadc-registry:[1.5.9,)'
     compile 'org.opencadc:cadc-vosi:[1.3.7,)'

--- a/minoc/build.gradle
+++ b/minoc/build.gradle
@@ -25,11 +25,11 @@ war {
 
 dependencies {
     compile 'log4j:log4j:[1.2,)'
-    compile 'org.opencadc:cadc-util:[1.3.16,)'
+    compile 'org.opencadc:cadc-util:[1.3.17,)'
     compile 'org.opencadc:cadc-log:[1.0,)'
     compile 'org.opencadc:cadc-registry:[1.5.9,)'
     compile 'org.opencadc:cadc-vosi:[1.3.7,)'
-    compile 'org.opencadc:cadc-rest:[1.2.20,)'
+    compile 'org.opencadc:cadc-rest:[1.2.21,)'
     compile 'org.opencadc:cadc-cdp:[1.0,)'
     compile 'org.opencadc:cadc-data-ops-fits:[0.1.1,)'
     compile 'org.opencadc:cadc-gms:[1.0.0,)'

--- a/minoc/src/intTest/java/org/opencadc/minoc/BasicOpsTest.java
+++ b/minoc/src/intTest/java/org/opencadc/minoc/BasicOpsTest.java
@@ -137,11 +137,11 @@ public class BasicOpsTest extends MinocTest {
             HttpGet get = new HttpGet(artifactURL, out);
             Subject.doAs(userSubject, new RunnableAction(get));
             Assert.assertNull(get.getThrowable());
-            String contentMD5 = get.getContentMD5();
+            URI checksumURI = get.getDigest();
             long contentLength = get.getContentLength();
             String contentType = get.getContentType();
             String contentEncoding = get.getContentEncoding();
-            Assert.assertEquals(computeMD5(data), contentMD5);
+            Assert.assertEquals(computeChecksumURI(data), checksumURI);
             Assert.assertEquals(data.length, contentLength);
             Assert.assertEquals(type, contentType);
             Assert.assertEquals(encoding, contentEncoding);
@@ -164,11 +164,11 @@ public class BasicOpsTest extends MinocTest {
             Subject.doAs(userSubject, new RunnableAction(head));
             log.warn("head output: " + bos.toString());
             Assert.assertNull(head.getThrowable());
-            contentMD5 = head.getContentMD5();
+            checksumURI = head.getDigest();
             contentLength = head.getContentLength();
             contentType = head.getContentType();
             contentEncoding = head.getContentEncoding();
-            Assert.assertEquals(computeMD5(data), contentMD5);
+            Assert.assertEquals(computeChecksumURI(data), checksumURI);
             Assert.assertEquals(data.length, contentLength);
             Assert.assertEquals(newType, contentType);
             Assert.assertEquals(newEncoding, contentEncoding);

--- a/minoc/src/intTest/java/org/opencadc/minoc/BasicOpsTest.java
+++ b/minoc/src/intTest/java/org/opencadc/minoc/BasicOpsTest.java
@@ -68,7 +68,6 @@
 package org.opencadc.minoc;
 
 import ca.nrc.cadc.auth.RunnableAction;
-import ca.nrc.cadc.net.DigestUtil;
 import ca.nrc.cadc.net.HttpDelete;
 import ca.nrc.cadc.net.HttpGet;
 import ca.nrc.cadc.net.HttpPost;
@@ -83,11 +82,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URL;
-import java.nio.charset.Charset;
 import java.security.PrivilegedExceptionAction;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 
 import javax.security.auth.Subject;
 
@@ -129,6 +126,7 @@ public class BasicOpsTest extends MinocTest {
             HttpUpload put = new HttpUpload(in, artifactURL);
             put.setRequestProperty(HttpTransfer.CONTENT_TYPE, type);
             put.setRequestProperty(HttpTransfer.CONTENT_ENCODING, encoding);
+            put.setDigest(computeChecksumURI(data));
 
             Subject.doAs(userSubject, new RunnableAction(put));
             Assert.assertNull(put.getThrowable());
@@ -155,6 +153,7 @@ public class BasicOpsTest extends MinocTest {
             params.put("contentEncoding", newEncoding);
             params.put("contentType", newType);
             HttpPost post = new HttpPost(artifactURL, params, false);
+            post.setDigest(computeChecksumURI(data));
             Subject.doAs(userSubject, new RunnableAction(post));
             Assert.assertNull(post.getThrowable());
 

--- a/minoc/src/intTest/java/org/opencadc/minoc/BasicOpsTest.java
+++ b/minoc/src/intTest/java/org/opencadc/minoc/BasicOpsTest.java
@@ -68,7 +68,7 @@
 package org.opencadc.minoc;
 
 import ca.nrc.cadc.auth.RunnableAction;
-import ca.nrc.cadc.net.Digest;
+import ca.nrc.cadc.net.DigestUtil;
 import ca.nrc.cadc.net.HttpDelete;
 import ca.nrc.cadc.net.HttpGet;
 import ca.nrc.cadc.net.HttpPost;
@@ -138,7 +138,7 @@ public class BasicOpsTest extends MinocTest {
             HttpGet get = new HttpGet(artifactURL, out);
             Subject.doAs(userSubject, new RunnableAction(get));
             Assert.assertNull(get.getThrowable());
-            URI checksumURI = Digest.getURI(get.getDigest());
+            URI checksumURI = DigestUtil.getURI(get.getDigest());
             long contentLength = get.getContentLength();
             String contentType = get.getContentType();
             String contentEncoding = get.getContentEncoding();
@@ -165,7 +165,7 @@ public class BasicOpsTest extends MinocTest {
             Subject.doAs(userSubject, new RunnableAction(head));
             log.warn("head output: " + bos.toString());
             Assert.assertNull(head.getThrowable());
-            checksumURI = Digest.getURI(head.getDigest());
+            checksumURI = DigestUtil.getURI(head.getDigest());
             contentLength = head.getContentLength();
             contentType = head.getContentType();
             contentEncoding = head.getContentEncoding();

--- a/minoc/src/intTest/java/org/opencadc/minoc/BasicOpsTest.java
+++ b/minoc/src/intTest/java/org/opencadc/minoc/BasicOpsTest.java
@@ -68,6 +68,7 @@
 package org.opencadc.minoc;
 
 import ca.nrc.cadc.auth.RunnableAction;
+import ca.nrc.cadc.net.Digest;
 import ca.nrc.cadc.net.HttpDelete;
 import ca.nrc.cadc.net.HttpGet;
 import ca.nrc.cadc.net.HttpPost;
@@ -137,7 +138,7 @@ public class BasicOpsTest extends MinocTest {
             HttpGet get = new HttpGet(artifactURL, out);
             Subject.doAs(userSubject, new RunnableAction(get));
             Assert.assertNull(get.getThrowable());
-            URI checksumURI = get.getDigest();
+            URI checksumURI = Digest.getURI(get.getDigest());
             long contentLength = get.getContentLength();
             String contentType = get.getContentType();
             String contentEncoding = get.getContentEncoding();
@@ -164,7 +165,7 @@ public class BasicOpsTest extends MinocTest {
             Subject.doAs(userSubject, new RunnableAction(head));
             log.warn("head output: " + bos.toString());
             Assert.assertNull(head.getThrowable());
-            checksumURI = head.getDigest();
+            checksumURI = Digest.getURI(head.getDigest());
             contentLength = head.getContentLength();
             contentType = head.getContentType();
             contentEncoding = head.getContentEncoding();

--- a/minoc/src/intTest/java/org/opencadc/minoc/BasicOpsTest.java
+++ b/minoc/src/intTest/java/org/opencadc/minoc/BasicOpsTest.java
@@ -138,7 +138,7 @@ public class BasicOpsTest extends MinocTest {
             HttpGet get = new HttpGet(artifactURL, out);
             Subject.doAs(userSubject, new RunnableAction(get));
             Assert.assertNull(get.getThrowable());
-            URI checksumURI = DigestUtil.getURI(get.getDigest());
+            URI checksumURI = get.getDigest();
             long contentLength = get.getContentLength();
             String contentType = get.getContentType();
             String contentEncoding = get.getContentEncoding();
@@ -165,7 +165,7 @@ public class BasicOpsTest extends MinocTest {
             Subject.doAs(userSubject, new RunnableAction(head));
             log.warn("head output: " + bos.toString());
             Assert.assertNull(head.getThrowable());
-            checksumURI = DigestUtil.getURI(head.getDigest());
+            checksumURI = head.getDigest();
             contentLength = head.getContentLength();
             contentType = head.getContentType();
             contentEncoding = head.getContentEncoding();

--- a/minoc/src/intTest/java/org/opencadc/minoc/FitsOperationsTest.java
+++ b/minoc/src/intTest/java/org/opencadc/minoc/FitsOperationsTest.java
@@ -117,7 +117,7 @@ public class FitsOperationsTest extends MinocTest {
     protected URL filesVaultURL;
 
     static {
-        Log4jInit.setLevel("org.opencadc.minoc", Level.DEBUG);
+        Log4jInit.setLevel("org.opencadc.minoc", Level.INFO);
         Log4jInit.setLevel("ca.nrc.cadc.net", Level.INFO);
     }
 

--- a/minoc/src/intTest/java/org/opencadc/minoc/FitsTest.java
+++ b/minoc/src/intTest/java/org/opencadc/minoc/FitsTest.java
@@ -86,7 +86,7 @@ public class FitsTest {
     private static final Logger LOGGER = Logger.getLogger(FitsTest.class);
 
     static {
-        Log4jInit.setLevel("org.opencadc", Level.DEBUG);
+        Log4jInit.setLevel("org.opencadc", Level.INFO);
     }
 
     private static final IFitsHeader[] HEADER_CARD_KEYS_TO_CHECK = new IFitsHeader[]{

--- a/minoc/src/intTest/java/org/opencadc/minoc/IncorrectPutMetadataTest.java
+++ b/minoc/src/intTest/java/org/opencadc/minoc/IncorrectPutMetadataTest.java
@@ -67,6 +67,7 @@
 
 package org.opencadc.minoc;
 
+import ca.nrc.cadc.net.Digest;
 import ca.nrc.cadc.net.HttpDelete;
 import ca.nrc.cadc.net.HttpGet;
 import ca.nrc.cadc.net.HttpTransfer;
@@ -135,7 +136,7 @@ public class IncorrectPutMetadataTest extends MinocTest {
                     HttpUpload put = new HttpUpload(in, artifactURL);
                     URI checksumURI = computeChecksumURI(incorrectData.getBytes());
                     String algorithm = checksumURI.getScheme();
-                    String checksum = HttpTransfer.base64Encode(checksumURI.getSchemeSpecificPart());
+                    String checksum = Digest.base64Encode(checksumURI.getSchemeSpecificPart());
                     put.setRequestProperty(HttpTransfer.DIGEST, String.format("%s=%s", algorithm, checksum));
                     put.setRequestProperty(HttpTransfer.CONTENT_LENGTH, Long.toString(bytes.length));
                     put.run();
@@ -309,7 +310,7 @@ public class IncorrectPutMetadataTest extends MinocTest {
                     HttpUpload put = new HttpUpload(in, artifactURL);
                     URI checksumURI = computeChecksumURI(bytes);
                     String algorithm = checksumURI.getScheme();
-                    String checksum = HttpTransfer.base64Encode(checksumURI.getSchemeSpecificPart());
+                    String checksum = Digest.base64Encode(checksumURI.getSchemeSpecificPart());
                     put.setRequestProperty(HttpTransfer.DIGEST, String.format("%s=%s", algorithm, checksum));
                     put.setRequestProperty(HttpTransfer.CONTENT_LENGTH, Long.toString((long) bytes.length - 1L));
                     put.run();
@@ -371,7 +372,7 @@ public class IncorrectPutMetadataTest extends MinocTest {
                     HttpUpload put = new HttpUpload(in, artifactURL);
                     URI checksumURI = computeChecksumURI(bytes);
                     String algorithm = checksumURI.getScheme();
-                    String checksum = HttpTransfer.base64Encode(checksumURI.getSchemeSpecificPart());
+                    String checksum = Digest.base64Encode(checksumURI.getSchemeSpecificPart());
                     put.setRequestProperty(HttpTransfer.DIGEST, String.format("%s=%s", algorithm, checksum));
                     put.setRequestProperty(HttpTransfer.CONTENT_LENGTH, Long.toString((long) bytes.length));
 

--- a/minoc/src/intTest/java/org/opencadc/minoc/IncorrectPutMetadataTest.java
+++ b/minoc/src/intTest/java/org/opencadc/minoc/IncorrectPutMetadataTest.java
@@ -133,7 +133,10 @@ public class IncorrectPutMetadataTest extends MinocTest {
                     // put file
                     InputStream in = new ByteArrayInputStream(bytes);
                     HttpUpload put = new HttpUpload(in, artifactURL);
-                    put.setRequestProperty(HttpTransfer.CONTENT_MD5, computeMD5(incorrectData.getBytes()));
+                    URI checksumURI = computeChecksumURI(incorrectData.getBytes());
+                    String algorithm = checksumURI.getScheme();
+                    String checksum = HttpTransfer.base64Encode(checksumURI.getSchemeSpecificPart());
+                    put.setRequestProperty(HttpTransfer.DIGEST, String.format("%s=%s", algorithm, checksum));
                     put.setRequestProperty(HttpTransfer.CONTENT_LENGTH, Long.toString(bytes.length));
                     put.run();
                     log.info("response code: " + put.getResponseCode() + " " + put.getThrowable());
@@ -304,7 +307,10 @@ public class IncorrectPutMetadataTest extends MinocTest {
                     // put file
                     InputStream in = new ByteArrayInputStream(bytes);
                     HttpUpload put = new HttpUpload(in, artifactURL);
-                    put.setRequestProperty(HttpTransfer.CONTENT_MD5, computeMD5(bytes));
+                    URI checksumURI = computeChecksumURI(bytes);
+                    String algorithm = checksumURI.getScheme();
+                    String checksum = HttpTransfer.base64Encode(checksumURI.getSchemeSpecificPart());
+                    put.setRequestProperty(HttpTransfer.DIGEST, String.format("%s=%s", algorithm, checksum));
                     put.setRequestProperty(HttpTransfer.CONTENT_LENGTH, Long.toString((long) bytes.length - 1L));
                     put.run();
                     log.info("response code: " + put.getResponseCode() + " " + put.getThrowable());
@@ -363,7 +369,10 @@ public class IncorrectPutMetadataTest extends MinocTest {
                     // put file
                     InputStream in = new ByteArrayInputStream(bytes);
                     HttpUpload put = new HttpUpload(in, artifactURL);
-                    put.setRequestProperty(HttpTransfer.CONTENT_MD5, computeMD5(bytes));
+                    URI checksumURI = computeChecksumURI(bytes);
+                    String algorithm = checksumURI.getScheme();
+                    String checksum = HttpTransfer.base64Encode(checksumURI.getSchemeSpecificPart());
+                    put.setRequestProperty(HttpTransfer.DIGEST, String.format("%s=%s", algorithm, checksum));
                     put.setRequestProperty(HttpTransfer.CONTENT_LENGTH, Long.toString((long) bytes.length));
 
                     put.run();

--- a/minoc/src/intTest/java/org/opencadc/minoc/IncorrectPutMetadataTest.java
+++ b/minoc/src/intTest/java/org/opencadc/minoc/IncorrectPutMetadataTest.java
@@ -67,7 +67,6 @@
 
 package org.opencadc.minoc;
 
-import ca.nrc.cadc.net.DigestUtil;
 import ca.nrc.cadc.net.HttpDelete;
 import ca.nrc.cadc.net.HttpGet;
 import ca.nrc.cadc.net.HttpTransfer;
@@ -134,10 +133,7 @@ public class IncorrectPutMetadataTest extends MinocTest {
                     // put file
                     InputStream in = new ByteArrayInputStream(bytes);
                     HttpUpload put = new HttpUpload(in, artifactURL);
-                    URI checksumURI = computeChecksumURI(incorrectData.getBytes());
-                    String algorithm = checksumURI.getScheme();
-                    String checksum = DigestUtil.base64Encode(checksumURI.getSchemeSpecificPart());
-                    put.setRequestProperty(HttpTransfer.DIGEST, String.format("%s=%s", algorithm, checksum));
+                    put.setDigest(computeChecksumURI(incorrectData.getBytes()));
                     put.setRequestProperty(HttpTransfer.CONTENT_LENGTH, Long.toString(bytes.length));
                     put.run();
                     log.info("response code: " + put.getResponseCode() + " " + put.getThrowable());
@@ -308,10 +304,7 @@ public class IncorrectPutMetadataTest extends MinocTest {
                     // put file
                     InputStream in = new ByteArrayInputStream(bytes);
                     HttpUpload put = new HttpUpload(in, artifactURL);
-                    URI checksumURI = computeChecksumURI(bytes);
-                    String algorithm = checksumURI.getScheme();
-                    String checksum = DigestUtil.base64Encode(checksumURI.getSchemeSpecificPart());
-                    put.setRequestProperty(HttpTransfer.DIGEST, String.format("%s=%s", algorithm, checksum));
+                    put.setDigest(computeChecksumURI(bytes));
                     put.setRequestProperty(HttpTransfer.CONTENT_LENGTH, Long.toString((long) bytes.length - 1L));
                     put.run();
                     log.info("response code: " + put.getResponseCode() + " " + put.getThrowable());
@@ -370,10 +363,7 @@ public class IncorrectPutMetadataTest extends MinocTest {
                     // put file
                     InputStream in = new ByteArrayInputStream(bytes);
                     HttpUpload put = new HttpUpload(in, artifactURL);
-                    URI checksumURI = computeChecksumURI(bytes);
-                    String algorithm = checksumURI.getScheme();
-                    String checksum = DigestUtil.base64Encode(checksumURI.getSchemeSpecificPart());
-                    put.setRequestProperty(HttpTransfer.DIGEST, String.format("%s=%s", algorithm, checksum));
+                    put.setDigest(computeChecksumURI(bytes));
                     put.setRequestProperty(HttpTransfer.CONTENT_LENGTH, Long.toString((long) bytes.length));
 
                     put.run();

--- a/minoc/src/intTest/java/org/opencadc/minoc/IncorrectPutMetadataTest.java
+++ b/minoc/src/intTest/java/org/opencadc/minoc/IncorrectPutMetadataTest.java
@@ -67,7 +67,7 @@
 
 package org.opencadc.minoc;
 
-import ca.nrc.cadc.net.Digest;
+import ca.nrc.cadc.net.DigestUtil;
 import ca.nrc.cadc.net.HttpDelete;
 import ca.nrc.cadc.net.HttpGet;
 import ca.nrc.cadc.net.HttpTransfer;
@@ -136,7 +136,7 @@ public class IncorrectPutMetadataTest extends MinocTest {
                     HttpUpload put = new HttpUpload(in, artifactURL);
                     URI checksumURI = computeChecksumURI(incorrectData.getBytes());
                     String algorithm = checksumURI.getScheme();
-                    String checksum = Digest.base64Encode(checksumURI.getSchemeSpecificPart());
+                    String checksum = DigestUtil.base64Encode(checksumURI.getSchemeSpecificPart());
                     put.setRequestProperty(HttpTransfer.DIGEST, String.format("%s=%s", algorithm, checksum));
                     put.setRequestProperty(HttpTransfer.CONTENT_LENGTH, Long.toString(bytes.length));
                     put.run();
@@ -310,7 +310,7 @@ public class IncorrectPutMetadataTest extends MinocTest {
                     HttpUpload put = new HttpUpload(in, artifactURL);
                     URI checksumURI = computeChecksumURI(bytes);
                     String algorithm = checksumURI.getScheme();
-                    String checksum = Digest.base64Encode(checksumURI.getSchemeSpecificPart());
+                    String checksum = DigestUtil.base64Encode(checksumURI.getSchemeSpecificPart());
                     put.setRequestProperty(HttpTransfer.DIGEST, String.format("%s=%s", algorithm, checksum));
                     put.setRequestProperty(HttpTransfer.CONTENT_LENGTH, Long.toString((long) bytes.length - 1L));
                     put.run();
@@ -372,7 +372,7 @@ public class IncorrectPutMetadataTest extends MinocTest {
                     HttpUpload put = new HttpUpload(in, artifactURL);
                     URI checksumURI = computeChecksumURI(bytes);
                     String algorithm = checksumURI.getScheme();
-                    String checksum = Digest.base64Encode(checksumURI.getSchemeSpecificPart());
+                    String checksum = DigestUtil.base64Encode(checksumURI.getSchemeSpecificPart());
                     put.setRequestProperty(HttpTransfer.DIGEST, String.format("%s=%s", algorithm, checksum));
                     put.setRequestProperty(HttpTransfer.CONTENT_LENGTH, Long.toString((long) bytes.length));
 

--- a/minoc/src/intTest/java/org/opencadc/minoc/MinocTest.java
+++ b/minoc/src/intTest/java/org/opencadc/minoc/MinocTest.java
@@ -132,7 +132,7 @@ public abstract class MinocTest {
         return ret;
     }
     
-    protected static String computeMD5(byte[] input) throws NoSuchAlgorithmException, IOException {
+    protected static URI computeChecksumURI(byte[] input) throws NoSuchAlgorithmException, IOException {
         MessageDigest md = MessageDigest.getInstance("MD5");
         InputStream in = new ByteArrayInputStream(input);
         DigestInputStream dis = new DigestInputStream(in, md);
@@ -142,7 +142,7 @@ public abstract class MinocTest {
             bytesRead = dis.read(buf);
         }
         byte[] digest = md.digest();
-        return HexUtil.toHex(digest);
+        return URI.create("md5:" + HexUtil.toHex(digest));
     }
 
 }

--- a/minoc/src/intTest/java/org/opencadc/minoc/ReplaceArtifactTest.java
+++ b/minoc/src/intTest/java/org/opencadc/minoc/ReplaceArtifactTest.java
@@ -150,7 +150,7 @@ public class ReplaceArtifactTest extends MinocTest {
                     HttpGet get = new HttpGet(artifactURL, out);
                     get.run();
                     Assert.assertNull(get.getThrowable());
-                    URI digest = DigestUtil.getURI(get.getDigest());
+                    URI digest = get.getDigest();
                     long contentLength = get.getContentLength();
                     Assert.assertEquals(computeChecksumURI(data1.getBytes()), digest);
                     Assert.assertEquals(data1.getBytes().length, contentLength);
@@ -166,7 +166,7 @@ public class ReplaceArtifactTest extends MinocTest {
                     get = new HttpGet(artifactURL, out);
                     get.run();
                     Assert.assertNull(get.getThrowable());
-                    digest = DigestUtil.getURI(get.getDigest());
+                    digest = get.getDigest();
                     contentLength = get.getContentLength();
                     Assert.assertEquals(computeChecksumURI(data2.getBytes()), digest);
                     Assert.assertEquals(data2.getBytes().length, contentLength);
@@ -224,7 +224,7 @@ public class ReplaceArtifactTest extends MinocTest {
                     HttpGet get = new HttpGet(artifactURL, out);
                     get.run();
                     Assert.assertNull(get.getThrowable());
-                    URI digest = DigestUtil.getURI(get.getDigest());
+                    URI digest = get.getDigest();
                     long contentLength = get.getContentLength();
                     Assert.assertEquals(computeChecksumURI(data2.getBytes()), digest);
                     Assert.assertEquals(data2.getBytes().length, contentLength);

--- a/minoc/src/intTest/java/org/opencadc/minoc/ReplaceArtifactTest.java
+++ b/minoc/src/intTest/java/org/opencadc/minoc/ReplaceArtifactTest.java
@@ -70,6 +70,7 @@ package org.opencadc.minoc;
 import ca.nrc.cadc.db.ConnectionConfig;
 import ca.nrc.cadc.db.DBConfig;
 import ca.nrc.cadc.db.DBUtil;
+import ca.nrc.cadc.net.Digest;
 import ca.nrc.cadc.net.HttpDelete;
 import ca.nrc.cadc.net.HttpGet;
 import ca.nrc.cadc.net.HttpUpload;
@@ -149,7 +150,7 @@ public class ReplaceArtifactTest extends MinocTest {
                     HttpGet get = new HttpGet(artifactURL, out);
                     get.run();
                     Assert.assertNull(get.getThrowable());
-                    URI digest = get.getDigest();
+                    URI digest = Digest.getURI(get.getDigest());
                     long contentLength = get.getContentLength();
                     Assert.assertEquals(computeChecksumURI(data1.getBytes()), digest);
                     Assert.assertEquals(data1.getBytes().length, contentLength);
@@ -165,7 +166,7 @@ public class ReplaceArtifactTest extends MinocTest {
                     get = new HttpGet(artifactURL, out);
                     get.run();
                     Assert.assertNull(get.getThrowable());
-                    digest = get.getDigest();
+                    digest = Digest.getURI(get.getDigest());
                     contentLength = get.getContentLength();
                     Assert.assertEquals(computeChecksumURI(data2.getBytes()), digest);
                     Assert.assertEquals(data2.getBytes().length, contentLength);
@@ -223,7 +224,7 @@ public class ReplaceArtifactTest extends MinocTest {
                     HttpGet get = new HttpGet(artifactURL, out);
                     get.run();
                     Assert.assertNull(get.getThrowable());
-                    URI digest = get.getDigest();
+                    URI digest = Digest.getURI(get.getDigest());
                     long contentLength = get.getContentLength();
                     Assert.assertEquals(computeChecksumURI(data2.getBytes()), digest);
                     Assert.assertEquals(data2.getBytes().length, contentLength);

--- a/minoc/src/intTest/java/org/opencadc/minoc/ReplaceArtifactTest.java
+++ b/minoc/src/intTest/java/org/opencadc/minoc/ReplaceArtifactTest.java
@@ -70,7 +70,7 @@ package org.opencadc.minoc;
 import ca.nrc.cadc.db.ConnectionConfig;
 import ca.nrc.cadc.db.DBConfig;
 import ca.nrc.cadc.db.DBUtil;
-import ca.nrc.cadc.net.Digest;
+import ca.nrc.cadc.net.DigestUtil;
 import ca.nrc.cadc.net.HttpDelete;
 import ca.nrc.cadc.net.HttpGet;
 import ca.nrc.cadc.net.HttpUpload;
@@ -150,7 +150,7 @@ public class ReplaceArtifactTest extends MinocTest {
                     HttpGet get = new HttpGet(artifactURL, out);
                     get.run();
                     Assert.assertNull(get.getThrowable());
-                    URI digest = Digest.getURI(get.getDigest());
+                    URI digest = DigestUtil.getURI(get.getDigest());
                     long contentLength = get.getContentLength();
                     Assert.assertEquals(computeChecksumURI(data1.getBytes()), digest);
                     Assert.assertEquals(data1.getBytes().length, contentLength);
@@ -166,7 +166,7 @@ public class ReplaceArtifactTest extends MinocTest {
                     get = new HttpGet(artifactURL, out);
                     get.run();
                     Assert.assertNull(get.getThrowable());
-                    digest = Digest.getURI(get.getDigest());
+                    digest = DigestUtil.getURI(get.getDigest());
                     contentLength = get.getContentLength();
                     Assert.assertEquals(computeChecksumURI(data2.getBytes()), digest);
                     Assert.assertEquals(data2.getBytes().length, contentLength);
@@ -224,7 +224,7 @@ public class ReplaceArtifactTest extends MinocTest {
                     HttpGet get = new HttpGet(artifactURL, out);
                     get.run();
                     Assert.assertNull(get.getThrowable());
-                    URI digest = Digest.getURI(get.getDigest());
+                    URI digest = DigestUtil.getURI(get.getDigest());
                     long contentLength = get.getContentLength();
                     Assert.assertEquals(computeChecksumURI(data2.getBytes()), digest);
                     Assert.assertEquals(data2.getBytes().length, contentLength);

--- a/minoc/src/intTest/java/org/opencadc/minoc/ReplaceArtifactTest.java
+++ b/minoc/src/intTest/java/org/opencadc/minoc/ReplaceArtifactTest.java
@@ -149,9 +149,9 @@ public class ReplaceArtifactTest extends MinocTest {
                     HttpGet get = new HttpGet(artifactURL, out);
                     get.run();
                     Assert.assertNull(get.getThrowable());
-                    String contentMD5 = get.getContentMD5();
+                    URI digest = get.getDigest();
                     long contentLength = get.getContentLength();
-                    Assert.assertEquals(computeMD5(data1.getBytes()), contentMD5);
+                    Assert.assertEquals(computeChecksumURI(data1.getBytes()), digest);
                     Assert.assertEquals(data1.getBytes().length, contentLength);
                     
                     // replace with new data
@@ -165,9 +165,9 @@ public class ReplaceArtifactTest extends MinocTest {
                     get = new HttpGet(artifactURL, out);
                     get.run();
                     Assert.assertNull(get.getThrowable());
-                    contentMD5 = get.getContentMD5();
+                    digest = get.getDigest();
                     contentLength = get.getContentLength();
-                    Assert.assertEquals(computeMD5(data2.getBytes()), contentMD5);
+                    Assert.assertEquals(computeChecksumURI(data2.getBytes()), digest);
                     Assert.assertEquals(data2.getBytes().length, contentLength);
                     
                     // delete
@@ -223,9 +223,9 @@ public class ReplaceArtifactTest extends MinocTest {
                     HttpGet get = new HttpGet(artifactURL, out);
                     get.run();
                     Assert.assertNull(get.getThrowable());
-                    String contentMD5 = get.getContentMD5();
+                    URI digest = get.getDigest();
                     long contentLength = get.getContentLength();
-                    Assert.assertEquals(computeMD5(data2.getBytes()), contentMD5);
+                    Assert.assertEquals(computeChecksumURI(data2.getBytes()), digest);
                     Assert.assertEquals(data2.getBytes().length, contentLength);
                     
                     Artifact actual = dao.get(artifactURI); // overwrite == new Artifact: get by URI
@@ -233,7 +233,7 @@ public class ReplaceArtifactTest extends MinocTest {
                     Assert.assertNotNull(actual);
                     Assert.assertNotNull("storageLocation", actual.storageLocation);
                     Assert.assertTrue(a.getContentLastModified().before(actual.getContentLastModified()));
-                    Assert.assertEquals(URI.create("md5:" + contentMD5), actual.getContentChecksum());
+                    Assert.assertEquals(digest, actual.getContentChecksum());
                     Assert.assertEquals(contentLength, actual.getContentLength().longValue());
                     
                     // delete

--- a/minoc/src/intTest/java/org/opencadc/minoc/ReplaceArtifactTest.java
+++ b/minoc/src/intTest/java/org/opencadc/minoc/ReplaceArtifactTest.java
@@ -70,7 +70,6 @@ package org.opencadc.minoc;
 import ca.nrc.cadc.db.ConnectionConfig;
 import ca.nrc.cadc.db.DBConfig;
 import ca.nrc.cadc.db.DBUtil;
-import ca.nrc.cadc.net.DigestUtil;
 import ca.nrc.cadc.net.HttpDelete;
 import ca.nrc.cadc.net.HttpGet;
 import ca.nrc.cadc.net.HttpUpload;
@@ -142,6 +141,7 @@ public class ReplaceArtifactTest extends MinocTest {
                     // put initial file
                     InputStream in = new ByteArrayInputStream(data1.getBytes());
                     HttpUpload put = new HttpUpload(in, artifactURL);
+                    put.setDigest(computeChecksumURI(data1.getBytes()));
                     put.run();
                     Assert.assertNull(put.getThrowable());
                     
@@ -158,6 +158,7 @@ public class ReplaceArtifactTest extends MinocTest {
                     // replace with new data
                     in = new ByteArrayInputStream(data2.getBytes());
                     put = new HttpUpload(in, artifactURL);
+                    put.setDigest(computeChecksumURI(data2.getBytes()));
                     put.run();
                     Assert.assertNull(put.getThrowable());
                     
@@ -216,6 +217,7 @@ public class ReplaceArtifactTest extends MinocTest {
                     // try to overwrite with actual
                     InputStream in = new ByteArrayInputStream(data2.getBytes());
                     HttpUpload put = new HttpUpload(in, artifactURL);
+                    put.setDigest(computeChecksumURI(data2.getBytes()));
                     put.run();
                     Assert.assertNull(put.getThrowable());
                     

--- a/minoc/src/intTest/java/org/opencadc/minoc/VosiCapabilitiesTest.java
+++ b/minoc/src/intTest/java/org/opencadc/minoc/VosiCapabilitiesTest.java
@@ -69,10 +69,8 @@
 
 package org.opencadc.minoc;
 
-import ca.nrc.cadc.auth.AuthMethod;
 import ca.nrc.cadc.reg.Capabilities;
 import ca.nrc.cadc.reg.Capability;
-import ca.nrc.cadc.reg.Interface;
 import ca.nrc.cadc.reg.Standards;
 import ca.nrc.cadc.util.Log4jInit;
 import ca.nrc.cadc.vosi.CapabilitiesTest;
@@ -89,8 +87,8 @@ public class VosiCapabilitiesTest extends CapabilitiesTest {
     private static final Logger log = Logger.getLogger(VosiCapabilitiesTest.class);
 
     static {
-        Log4jInit.setLevel("ca.nrc.cadc.vosi", Level.DEBUG);
-        Log4jInit.setLevel("org.opencadc.inventory", Level.DEBUG);
+        Log4jInit.setLevel("ca.nrc.cadc.vosi", Level.INFO);
+        Log4jInit.setLevel("org.opencadc.inventory", Level.INFO);
     }
     
     public VosiCapabilitiesTest() {

--- a/minoc/src/main/java/org/opencadc/minoc/HeadAction.java
+++ b/minoc/src/main/java/org/opencadc/minoc/HeadAction.java
@@ -67,6 +67,7 @@
 
 package org.opencadc.minoc;
 
+import ca.nrc.cadc.net.Digest;
 import ca.nrc.cadc.net.HttpTransfer;
 import ca.nrc.cadc.rest.SyncOutput;
 import org.apache.log4j.Logger;
@@ -109,7 +110,7 @@ public class HeadAction extends ArtifactAction {
      */
     public static void setHeaders(Artifact artifact, SyncOutput syncOutput) {
         String algorithm = artifact.getContentChecksum().getScheme();
-        String base64Checksum = HttpTransfer.base64Encode(artifact.getContentChecksum().getSchemeSpecificPart());
+        String base64Checksum = Digest.base64Encode(artifact.getContentChecksum().getSchemeSpecificPart());
         String digest = String.format("%s=%s", algorithm, base64Checksum);
         syncOutput.setHeader("Digest", digest);
         syncOutput.setHeader("Content-Length", artifact.getContentLength());

--- a/minoc/src/main/java/org/opencadc/minoc/HeadAction.java
+++ b/minoc/src/main/java/org/opencadc/minoc/HeadAction.java
@@ -67,8 +67,7 @@
 
 package org.opencadc.minoc;
 
-import ca.nrc.cadc.net.Digest;
-import ca.nrc.cadc.net.HttpTransfer;
+import ca.nrc.cadc.net.DigestUtil;
 import ca.nrc.cadc.rest.SyncOutput;
 import org.apache.log4j.Logger;
 import org.opencadc.inventory.Artifact;
@@ -110,7 +109,7 @@ public class HeadAction extends ArtifactAction {
      */
     public static void setHeaders(Artifact artifact, SyncOutput syncOutput) {
         String algorithm = artifact.getContentChecksum().getScheme();
-        String base64Checksum = Digest.base64Encode(artifact.getContentChecksum().getSchemeSpecificPart());
+        String base64Checksum = DigestUtil.base64Encode(artifact.getContentChecksum().getSchemeSpecificPart());
         String digest = String.format("%s=%s", algorithm, base64Checksum);
         syncOutput.setHeader("Digest", digest);
         syncOutput.setHeader("Content-Length", artifact.getContentLength());

--- a/minoc/src/main/java/org/opencadc/minoc/HeadAction.java
+++ b/minoc/src/main/java/org/opencadc/minoc/HeadAction.java
@@ -108,10 +108,7 @@ public class HeadAction extends ArtifactAction {
      * @param syncOutput The target response
      */
     public static void setHeaders(Artifact artifact, SyncOutput syncOutput) {
-        String algorithm = artifact.getContentChecksum().getScheme();
-        String base64Checksum = DigestUtil.base64Encode(artifact.getContentChecksum().getSchemeSpecificPart());
-        String digest = String.format("%s=%s", algorithm, base64Checksum);
-        syncOutput.setHeader("Digest", digest);
+        syncOutput.setDigest(artifact.getContentChecksum());
         syncOutput.setHeader("Content-Length", artifact.getContentLength());
         String filename = InventoryUtil.computeArtifactFilename(artifact.getURI());
         syncOutput.setHeader("Content-Disposition", "attachment; filename=\"" + filename + "\"");

--- a/minoc/src/main/java/org/opencadc/minoc/HeadAction.java
+++ b/minoc/src/main/java/org/opencadc/minoc/HeadAction.java
@@ -67,6 +67,7 @@
 
 package org.opencadc.minoc;
 
+import ca.nrc.cadc.net.HttpTransfer;
 import ca.nrc.cadc.rest.SyncOutput;
 import org.apache.log4j.Logger;
 import org.opencadc.inventory.Artifact;
@@ -107,7 +108,10 @@ public class HeadAction extends ArtifactAction {
      * @param syncOutput The target response
      */
     public static void setHeaders(Artifact artifact, SyncOutput syncOutput) {
-        syncOutput.setHeader("Content-MD5", artifact.getContentChecksum().getSchemeSpecificPart());
+        String algorithm = artifact.getContentChecksum().getScheme();
+        String base64Checksum = HttpTransfer.base64Encode(artifact.getContentChecksum().getSchemeSpecificPart());
+        String digest = String.format("%s=%s", algorithm, base64Checksum);
+        syncOutput.setHeader("Digest", digest);
         syncOutput.setHeader("Content-Length", artifact.getContentLength());
         String filename = InventoryUtil.computeArtifactFilename(artifact.getURI());
         syncOutput.setHeader("Content-Disposition", "attachment; filename=\"" + filename + "\"");

--- a/minoc/src/main/java/org/opencadc/minoc/PutAction.java
+++ b/minoc/src/main/java/org/opencadc/minoc/PutAction.java
@@ -71,6 +71,7 @@ import ca.nrc.cadc.db.TransactionManager;
 import ca.nrc.cadc.io.ByteLimitExceededException;
 import ca.nrc.cadc.io.ReadException;
 import ca.nrc.cadc.io.WriteException;
+import ca.nrc.cadc.net.Digest;
 import ca.nrc.cadc.net.HttpTransfer;
 import ca.nrc.cadc.net.PreconditionFailedException;
 import ca.nrc.cadc.net.ResourceNotFoundException;
@@ -147,7 +148,7 @@ public class PutAction extends ArtifactAction {
         log.debug("Content-Encoding: " + encodingHeader);
         log.debug("Content-Type: " + typeHeader);
         
-        URI contentChecksum = HttpTransfer.parseDigest(digestHeader);
+        URI contentChecksum = Digest.getURI(digestHeader);
         Long contentLength = null;
         if (lengthHeader != null) {
             try {

--- a/minoc/src/main/java/org/opencadc/minoc/PutAction.java
+++ b/minoc/src/main/java/org/opencadc/minoc/PutAction.java
@@ -71,8 +71,7 @@ import ca.nrc.cadc.db.TransactionManager;
 import ca.nrc.cadc.io.ByteLimitExceededException;
 import ca.nrc.cadc.io.ReadException;
 import ca.nrc.cadc.io.WriteException;
-import ca.nrc.cadc.net.Digest;
-import ca.nrc.cadc.net.HttpTransfer;
+import ca.nrc.cadc.net.DigestUtil;
 import ca.nrc.cadc.net.PreconditionFailedException;
 import ca.nrc.cadc.net.ResourceNotFoundException;
 import ca.nrc.cadc.net.TransientException;
@@ -83,7 +82,6 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Date;
 import org.apache.log4j.Logger;
 import org.opencadc.inventory.Artifact;
@@ -148,7 +146,7 @@ public class PutAction extends ArtifactAction {
         log.debug("Content-Encoding: " + encodingHeader);
         log.debug("Content-Type: " + typeHeader);
         
-        URI contentChecksum = Digest.getURI(digestHeader);
+        URI contentChecksum = DigestUtil.getURI(digestHeader);
         Long contentLength = null;
         if (lengthHeader != null) {
             try {

--- a/minoc/src/main/java/org/opencadc/minoc/PutAction.java
+++ b/minoc/src/main/java/org/opencadc/minoc/PutAction.java
@@ -71,7 +71,6 @@ import ca.nrc.cadc.db.TransactionManager;
 import ca.nrc.cadc.io.ByteLimitExceededException;
 import ca.nrc.cadc.io.ReadException;
 import ca.nrc.cadc.io.WriteException;
-import ca.nrc.cadc.net.DigestUtil;
 import ca.nrc.cadc.net.PreconditionFailedException;
 import ca.nrc.cadc.net.ResourceNotFoundException;
 import ca.nrc.cadc.net.TransientException;
@@ -137,16 +136,15 @@ public class PutAction extends ArtifactAction {
         
         initAndAuthorize(WriteGrant.class);
 
-        String digestHeader = syncInput.getHeader("Digest");
+        URI digest = syncInput.getDigest();
         String lengthHeader = syncInput.getHeader("Content-Length");
         String encodingHeader = syncInput.getHeader("Content-Encoding");
         String typeHeader = syncInput.getHeader("Content-Type");
-        log.debug("Digest: " + digestHeader);
+        log.debug("Digest: " + (digest == null ? null : digest.toASCIIString()));
         log.debug("Content-Length: " + lengthHeader);
         log.debug("Content-Encoding: " + encodingHeader);
         log.debug("Content-Type: " + typeHeader);
-        
-        URI contentChecksum = DigestUtil.getURI(digestHeader);
+
         Long contentLength = null;
         if (lengthHeader != null) {
             try {
@@ -155,11 +153,10 @@ public class PutAction extends ArtifactAction {
                 throw new IllegalArgumentException("Illegal Content-Length header: " + lengthHeader);
             }
         }
-        log.debug("Content-Checksum: " + contentChecksum);
         log.debug("Content-Length: " + contentLength);
                 
         NewArtifact newArtifact = new NewArtifact(artifactURI);
-        newArtifact.contentChecksum = contentChecksum;
+        newArtifact.contentChecksum = digest;
         newArtifact.contentLength = contentLength;
 
         final Profiler profiler = new Profiler(PutAction.class);

--- a/minoc/src/main/java/org/opencadc/minoc/PutAction.java
+++ b/minoc/src/main/java/org/opencadc/minoc/PutAction.java
@@ -71,6 +71,7 @@ import ca.nrc.cadc.db.TransactionManager;
 import ca.nrc.cadc.io.ByteLimitExceededException;
 import ca.nrc.cadc.io.ReadException;
 import ca.nrc.cadc.io.WriteException;
+import ca.nrc.cadc.net.HttpTransfer;
 import ca.nrc.cadc.net.PreconditionFailedException;
 import ca.nrc.cadc.net.ResourceNotFoundException;
 import ca.nrc.cadc.net.TransientException;
@@ -136,25 +137,18 @@ public class PutAction extends ArtifactAction {
     public void doAction() throws Exception {
         
         initAndAuthorize(WriteGrant.class);
-        
-        String md5Header = syncInput.getHeader("Content-MD5");
+
+        String digestHeader = syncInput.getHeader("Digest");
         String lengthHeader = syncInput.getHeader("Content-Length");
         String encodingHeader = syncInput.getHeader("Content-Encoding");
         String typeHeader = syncInput.getHeader("Content-Type");
-        log.debug("Content-MD5: " + md5Header);
+        log.debug("Digest: " + digestHeader);
         log.debug("Content-Length: " + lengthHeader);
         log.debug("Content-Encoding: " + encodingHeader);
         log.debug("Content-Type: " + typeHeader);
         
-        URI contentMD5 = null;
+        URI contentChecksum = HttpTransfer.parseDigest(digestHeader);
         Long contentLength = null;
-        if (md5Header != null) {
-            try {
-                contentMD5 = new URI("md5:" + md5Header);
-            } catch (URISyntaxException e) {
-                throw new IllegalArgumentException("Illegal Content-MD5 header: " + md5Header);
-            }
-        }
         if (lengthHeader != null) {
             try {
                 contentLength = new Long(lengthHeader);
@@ -162,11 +156,11 @@ public class PutAction extends ArtifactAction {
                 throw new IllegalArgumentException("Illegal Content-Length header: " + lengthHeader);
             }
         }
-        log.debug("Content-MD5: " + contentMD5);
+        log.debug("Content-Checksum: " + contentChecksum);
         log.debug("Content-Length: " + contentLength);
                 
         NewArtifact newArtifact = new NewArtifact(artifactURI);
-        newArtifact.contentChecksum = contentMD5;
+        newArtifact.contentChecksum = contentChecksum;
         newArtifact.contentLength = contentLength;
 
         final Profiler profiler = new Profiler(PutAction.class);

--- a/minoc/src/test/java/org/opencadc/minoc/ArtifactActionTest.java
+++ b/minoc/src/test/java/org/opencadc/minoc/ArtifactActionTest.java
@@ -83,7 +83,7 @@ public class ArtifactActionTest {
     private static final Logger log = Logger.getLogger(ArtifactActionTest.class);
 
     static {
-        Log4jInit.setLevel("org.opencadc.minoc", Level.DEBUG);
+        Log4jInit.setLevel("org.opencadc.minoc", Level.INFO);
     }
     
     class TestSyncInput extends SyncInput {

--- a/minoc/src/test/java/org/opencadc/minoc/operations/ProxyRandomAccessFitsTest.java
+++ b/minoc/src/test/java/org/opencadc/minoc/operations/ProxyRandomAccessFitsTest.java
@@ -97,8 +97,8 @@ public class ProxyRandomAccessFitsTest {
     private static final Logger log = Logger.getLogger(ProxyRandomAccessFitsTest.class);
 
     static {
-        Log4jInit.setLevel("org.opencadc.minoc.operations", Level.DEBUG);
-        //Log4jInit.setLevel("org.opencadc.inventory.storage.fs", Level.DEBUG);
+        Log4jInit.setLevel("org.opencadc.minoc.operations", Level.INFO);
+        //Log4jInit.setLevel("org.opencadc.inventory.storage.fs", Level.INFO);
     }
 
     public ProxyRandomAccessFitsTest() { 


### PR DESCRIPTION
open-cadc/core branch CADC-8679 contains the cadc-util changes to support the Digest header