### PR TITLE
CADC-9366 - only members of configured groups are allowed to query luskan

### DIFF
--- a/luskan/README.md
+++ b/luskan/README.md
@@ -51,7 +51,13 @@ org.opencadc.luskan.resultsDir={absolute path to directory for async results}
 # true if luskan is running on a storage site, false or not set if
 # running on a global site
 org.opencadc.luskan.isStorageSite={true|false}
+
+# groups whose members have authorization to query luskan 
+org.opencadc.luskan.allowedGroup={authorized group}
 ```
+
+`org.opencadc.luskan.allowedGroup` specifies the group(s) whose members have authorization to make calls to the service. 
+The value is a list of group identifiers (e.g. ivo://cadc.nrc.ca/gms?CADC), one line per group.
 
 ### LocalAuthority.properties
 The LocalAuthority.properties file specifies which local service is authoritative for various site-wide functions. The keys

--- a/luskan/src/intTest/README.md
+++ b/luskan/src/intTest/README.md
@@ -1,0 +1,12 @@
+# luskan integration tests
+
+Runs tests against `ivo://cadc.nrc.ca/luskan` so that should resolve 
+to a locally running luskan instance using a test database.
+
+Client certificates named `luskan-test-auth.pem` and `luskan-test-noauth.pem` 
+must exist in the directory $A/test-certificates.
+The `luskan-test-auth.pem` user has authorization to call this service.
+The `luskan-test-noauth.pem` user is not authorized to call this service.
+
+The integration tests expect the following entry in `luskan.properties`.
+`org.opencadc.luskan.allowedGroup={ group with member whose uidentity for luskan-test-auth.pem }`

--- a/luskan/src/intTest/java/org/opencadc/luskan/AuthQueryTest.java
+++ b/luskan/src/intTest/java/org/opencadc/luskan/AuthQueryTest.java
@@ -78,7 +78,6 @@ import ca.nrc.cadc.reg.client.RegistryClient;
 import ca.nrc.cadc.util.FileUtil;
 import ca.nrc.cadc.util.Log4jInit;
 import java.io.File;
-import java.net.URI;
 import java.net.URL;
 import java.security.AccessControlException;
 import java.security.PrivilegedExceptionAction;
@@ -88,10 +87,9 @@ import org.apache.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class QueryRunnerImplTest {
-    private static final Logger log = Logger.getLogger(QueryRunnerImplTest.class);
+public class AuthQueryTest {
+    private static final Logger log = Logger.getLogger(AuthQueryTest.class);
 
-    public static final URI LUSKAN_URI = URI.create("ivo://cadc.nrc.ca/luskan");
     protected URL luskanURL;
     protected Subject anonymousSubject;
     protected Subject authorizedSubject;
@@ -101,18 +99,18 @@ public class QueryRunnerImplTest {
         Log4jInit.setLevel("org.opencadc.luskan", Level.INFO);
     }
 
-    public QueryRunnerImplTest() {
+    public AuthQueryTest() {
         RegistryClient regClient = new RegistryClient();
-        luskanURL = regClient.getServiceURL(LUSKAN_URI, Standards.TAP_10, AuthMethod.CERT);
+        luskanURL = regClient.getServiceURL(Constants.RESOURCE_ID, Standards.TAP_10, AuthMethod.CERT);
         log.debug("luskan URL: " + luskanURL);
 
         anonymousSubject = AuthenticationUtil.getAnonSubject();
 
-        File cert = FileUtil.getFileFromResource("luskan-test-noauth.pem", QueryRunnerImplTest.class);
+        File cert = FileUtil.getFileFromResource("luskan-test-noauth.pem", AuthQueryTest.class);
         notAuthorizedSubject = SSLUtil.createSubject(cert);
         log.debug("not authorized Subject: " + notAuthorizedSubject);
 
-        cert = FileUtil.getFileFromResource("luskan-test-auth.pem", QueryRunnerImplTest.class);
+        cert = FileUtil.getFileFromResource("luskan-test-auth.pem", AuthQueryTest.class);
         authorizedSubject = SSLUtil.createSubject(cert);
         log.debug("authorized Subject: " + authorizedSubject);
     }

--- a/luskan/src/intTest/java/org/opencadc/luskan/LuskanAsyncErrorTest.java
+++ b/luskan/src/intTest/java/org/opencadc/luskan/LuskanAsyncErrorTest.java
@@ -96,7 +96,7 @@ public class LuskanAsyncErrorTest extends TapAsyncErrorTest
     public LuskanAsyncErrorTest()
     { 
         super(Constants.RESOURCE_ID);
-        File testCertFile = FileUtil.getFileFromResource("x509_CADCAuthtest1.pem", LuskanSyncQueryTest.class);
+        File testCertFile = FileUtil.getFileFromResource("luskan-test-auth.pem", LuskanSyncQueryTest.class);
         setSubject(SSLUtil.createSubject(testCertFile));
         // re-use SyncResultTest files
         File testFile = FileUtil.getFileFromResource("AsyncErrorTest.foo.properties", LuskanSyncQueryTest.class);

--- a/luskan/src/intTest/java/org/opencadc/luskan/LuskanAsyncErrorTest.java
+++ b/luskan/src/intTest/java/org/opencadc/luskan/LuskanAsyncErrorTest.java
@@ -96,7 +96,7 @@ public class LuskanAsyncErrorTest extends TapAsyncErrorTest
     public LuskanAsyncErrorTest()
     { 
         super(Constants.RESOURCE_ID);
-        File testCertFile = FileUtil.getFileFromResource("x509_CADCAnontest1.pem", LuskanSyncQueryTest.class);
+        File testCertFile = FileUtil.getFileFromResource("x509_CADCAuthtest1.pem", LuskanSyncQueryTest.class);
         setSubject(SSLUtil.createSubject(testCertFile));
         // re-use SyncResultTest files
         File testFile = FileUtil.getFileFromResource("AsyncErrorTest.foo.properties", LuskanSyncQueryTest.class);

--- a/luskan/src/intTest/java/org/opencadc/luskan/LuskanAsyncQueryTest.java
+++ b/luskan/src/intTest/java/org/opencadc/luskan/LuskanAsyncQueryTest.java
@@ -96,7 +96,7 @@ public class LuskanAsyncQueryTest extends TapAsyncQueryTest
     public LuskanAsyncQueryTest()
     { 
         super(Constants.RESOURCE_ID);
-        File testCertFile = FileUtil.getFileFromResource("x509_CADCAuthtest1.pem", LuskanSyncQueryTest.class);
+        File testCertFile = FileUtil.getFileFromResource("luskan-test-auth.pem", LuskanSyncQueryTest.class);
         setSubject(SSLUtil.createSubject(testCertFile));
         // re-use SyncResultTest files
         File testFile = FileUtil.getFileFromResource("AsyncResultTest-ts-columns.properties", LuskanSyncQueryTest.class);

--- a/luskan/src/intTest/java/org/opencadc/luskan/LuskanAsyncQueryTest.java
+++ b/luskan/src/intTest/java/org/opencadc/luskan/LuskanAsyncQueryTest.java
@@ -96,7 +96,7 @@ public class LuskanAsyncQueryTest extends TapAsyncQueryTest
     public LuskanAsyncQueryTest()
     { 
         super(Constants.RESOURCE_ID);
-        File testCertFile = FileUtil.getFileFromResource("x509_CADCAnontest1.pem", LuskanSyncQueryTest.class);
+        File testCertFile = FileUtil.getFileFromResource("x509_CADCAuthtest1.pem", LuskanSyncQueryTest.class);
         setSubject(SSLUtil.createSubject(testCertFile));
         // re-use SyncResultTest files
         File testFile = FileUtil.getFileFromResource("AsyncResultTest-ts-columns.properties", LuskanSyncQueryTest.class);

--- a/luskan/src/intTest/java/org/opencadc/luskan/LuskanSyncErrorTest.java
+++ b/luskan/src/intTest/java/org/opencadc/luskan/LuskanSyncErrorTest.java
@@ -96,7 +96,7 @@ public class LuskanSyncErrorTest extends TapSyncErrorTest
     public LuskanSyncErrorTest()
     { 
         super(Constants.RESOURCE_ID);
-        File testCertFile = FileUtil.getFileFromResource("x509_CADCAuthtest1.pem", LuskanSyncQueryTest.class);
+        File testCertFile = FileUtil.getFileFromResource("luskan-test-auth.pem", LuskanSyncQueryTest.class);
         setSubject(SSLUtil.createSubject(testCertFile));
         // re-use SyncResultTest files
         File testFile = FileUtil.getFileFromResource("SyncErrorTest-ATTEMPT-DELETE.properties", LuskanSyncErrorTest.class);

--- a/luskan/src/intTest/java/org/opencadc/luskan/LuskanSyncErrorTest.java
+++ b/luskan/src/intTest/java/org/opencadc/luskan/LuskanSyncErrorTest.java
@@ -96,7 +96,7 @@ public class LuskanSyncErrorTest extends TapSyncErrorTest
     public LuskanSyncErrorTest()
     { 
         super(Constants.RESOURCE_ID);
-        File testCertFile = FileUtil.getFileFromResource("x509_CADCAnontest1.pem", LuskanSyncQueryTest.class);
+        File testCertFile = FileUtil.getFileFromResource("x509_CADCAuthtest1.pem", LuskanSyncQueryTest.class);
         setSubject(SSLUtil.createSubject(testCertFile));
         // re-use SyncResultTest files
         File testFile = FileUtil.getFileFromResource("SyncErrorTest-ATTEMPT-DELETE.properties", LuskanSyncErrorTest.class);

--- a/luskan/src/intTest/java/org/opencadc/luskan/LuskanSyncQueryTest.java
+++ b/luskan/src/intTest/java/org/opencadc/luskan/LuskanSyncQueryTest.java
@@ -94,7 +94,7 @@ public class LuskanSyncQueryTest extends TapSyncQueryTest {
 
     public LuskanSyncQueryTest() {
         super(Constants.RESOURCE_ID);
-        File testCertFile = FileUtil.getFileFromResource("x509_CADCAnontest1.pem", LuskanSyncQueryTest.class);
+        File testCertFile = FileUtil.getFileFromResource("x509_CADCAuthtest1.pem", LuskanSyncQueryTest.class);
         setSubject(SSLUtil.createSubject(testCertFile));
         // re-use SyncResultTest files
         File testFile = FileUtil.getFileFromResource("SyncResultTest-ts-columns.properties", LuskanSyncQueryTest.class);

--- a/luskan/src/intTest/java/org/opencadc/luskan/LuskanSyncQueryTest.java
+++ b/luskan/src/intTest/java/org/opencadc/luskan/LuskanSyncQueryTest.java
@@ -94,7 +94,7 @@ public class LuskanSyncQueryTest extends TapSyncQueryTest {
 
     public LuskanSyncQueryTest() {
         super(Constants.RESOURCE_ID);
-        File testCertFile = FileUtil.getFileFromResource("x509_CADCAuthtest1.pem", LuskanSyncQueryTest.class);
+        File testCertFile = FileUtil.getFileFromResource("luskan-test-auth.pem", LuskanSyncQueryTest.class);
         setSubject(SSLUtil.createSubject(testCertFile));
         // re-use SyncResultTest files
         File testFile = FileUtil.getFileFromResource("SyncResultTest-ts-columns.properties", LuskanSyncQueryTest.class);

--- a/luskan/src/intTest/java/org/opencadc/luskan/QueryRunnerImplTest.java
+++ b/luskan/src/intTest/java/org/opencadc/luskan/QueryRunnerImplTest.java
@@ -1,0 +1,174 @@
+/*
+ ************************************************************************
+ *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+ **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+ *
+ *  (c) 2021.                            (c) 2021.
+ *  Government of Canada                 Gouvernement du Canada
+ *  National Research Council            Conseil national de recherches
+ *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+ *  All rights reserved                  Tous droits réservés
+ *
+ *  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+ *  expressed, implied, or               énoncée, implicite ou légale,
+ *  statutory, of any kind with          de quelque nature que ce
+ *  respect to the software,             soit, concernant le logiciel,
+ *  including without limitation         y compris sans restriction
+ *  any warranty of merchantability      toute garantie de valeur
+ *  or fitness for a particular          marchande ou de pertinence
+ *  purpose. NRC shall not be            pour un usage particulier.
+ *  liable in any event for any          Le CNRC ne pourra en aucun cas
+ *  damages, whether direct or           être tenu responsable de tout
+ *  indirect, special or general,        dommage, direct ou indirect,
+ *  consequential or incidental,         particulier ou général,
+ *  arising from the use of the          accessoire ou fortuit, résultant
+ *  software.  Neither the name          de l'utilisation du logiciel. Ni
+ *  of the National Research             le nom du Conseil National de
+ *  Council of Canada nor the            Recherches du Canada ni les noms
+ *  names of its contributors may        de ses  participants ne peuvent
+ *  be used to endorse or promote        être utilisés pour approuver ou
+ *  products derived from this           promouvoir les produits dérivés
+ *  software without specific prior      de ce logiciel sans autorisation
+ *  written permission.                  préalable et particulière
+ *                                       par écrit.
+ *
+ *  This file is part of the             Ce fichier fait partie du projet
+ *  OpenCADC project.                    OpenCADC.
+ *
+ *  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+ *  you can redistribute it and/or       vous pouvez le redistribuer ou le
+ *  modify it under the terms of         modifier suivant les termes de
+ *  the GNU Affero General Public        la “GNU Affero General Public
+ *  License as published by the          License” telle que publiée
+ *  Free Software Foundation,            par la Free Software Foundation
+ *  either version 3 of the              : soit la version 3 de cette
+ *  License, or (at your option)         licence, soit (à votre gré)
+ *  any later version.                   toute version ultérieure.
+ *
+ *  OpenCADC is distributed in the       OpenCADC est distribué
+ *  hope that it will be useful,         dans l’espoir qu’il vous
+ *  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+ *  without even the implied             GARANTIE : sans même la garantie
+ *  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+ *  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+ *  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+ *  General Public License for           Générale Publique GNU Affero
+ *  more details.                        pour plus de détails.
+ *
+ *  You should have received             Vous devriez avoir reçu une
+ *  a copy of the GNU Affero             copie de la Licence Générale
+ *  General Public License along         Publique GNU Affero avec
+ *  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+ *  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+ *                                       <http://www.gnu.org/licenses/>.
+ *
+ *  : 5 $
+ *
+ ************************************************************************
+ */
+
+package org.opencadc.luskan;
+
+import ca.nrc.cadc.auth.AuthMethod;
+import ca.nrc.cadc.auth.AuthenticationUtil;
+import ca.nrc.cadc.auth.SSLUtil;
+import ca.nrc.cadc.net.HttpGet;
+import ca.nrc.cadc.reg.Standards;
+import ca.nrc.cadc.reg.client.RegistryClient;
+import ca.nrc.cadc.util.FileUtil;
+import ca.nrc.cadc.util.Log4jInit;
+import java.io.File;
+import java.net.URI;
+import java.net.URL;
+import java.security.AccessControlException;
+import java.security.PrivilegedExceptionAction;
+import javax.security.auth.Subject;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class QueryRunnerImplTest {
+    private static final Logger log = Logger.getLogger(QueryRunnerImplTest.class);
+
+    public static final URI LUSKAN_URI = URI.create("ivo://cadc.nrc.ca/luskan");
+    protected URL luskanURL;
+    protected Subject anonymousSubject;
+    protected Subject authorizedSubject;
+    protected Subject notAuthorizedSubject;
+
+    static {
+        Log4jInit.setLevel("org.opencadc.luskan", Level.INFO);
+    }
+
+    public QueryRunnerImplTest() {
+        RegistryClient regClient = new RegistryClient();
+        luskanURL = regClient.getServiceURL(LUSKAN_URI, Standards.TAP_10, AuthMethod.CERT);
+        log.debug("luskan URL: " + luskanURL);
+
+        anonymousSubject = AuthenticationUtil.getAnonSubject();
+
+        File cert = FileUtil.getFileFromResource("luskan-test-noauth.pem", QueryRunnerImplTest.class);
+        notAuthorizedSubject = SSLUtil.createSubject(cert);
+        log.debug("not authorized Subject: " + notAuthorizedSubject);
+
+        cert = FileUtil.getFileFromResource("luskan-test-auth.pem", QueryRunnerImplTest.class);
+        authorizedSubject = SSLUtil.createSubject(cert);
+        log.debug("authorized Subject: " + authorizedSubject);
+    }
+
+    @Test
+    public void anonymousTest() throws Exception {
+        String query = luskanURL.toExternalForm() + "/sync?LANG=ADQL&QUERY=SELECT+TOP+1+*+FROM+inventory.Artifact";
+        log.debug("query: " + query);
+        HttpGet httpGet = new HttpGet(new URL(query), true);
+        Subject.doAs(anonymousSubject, new PrivilegedExceptionAction<Object>() {
+            public Object run() throws Exception {
+                try {
+                    httpGet.prepare();
+                    Assert.fail("anonymous access should throw exception");
+                } catch (AccessControlException expected) {
+                    Assert.assertEquals(403, httpGet.getResponseCode());
+                }
+                return null;
+            }
+        });
+    }
+
+    @Test
+    public void notAuthorizedTest() throws Exception {
+        String query = luskanURL.toExternalForm() + "/sync?LANG=ADQL&QUERY=SELECT+TOP+1+*+FROM+inventory.Artifact";
+        log.debug("query: " + query);
+        HttpGet httpGet = new HttpGet(new URL(query), true);
+        Subject.doAs(notAuthorizedSubject, new PrivilegedExceptionAction<Object>() {
+            public Object run() throws Exception {
+                try {
+                    httpGet.prepare();
+                    Assert.fail("unauthorized access should throw exception");
+                } catch (AccessControlException expected) {
+                    Assert.assertEquals(403, httpGet.getResponseCode());
+                }
+                return null;
+            }
+        });
+    }
+
+    @Test
+    public void authorizedTest() throws Exception {
+        String query = luskanURL.toExternalForm() + "/sync?LANG=ADQL&QUERY=SELECT+TOP+1+*+FROM+inventory.Artifact";
+        log.debug("query: " + query);
+        HttpGet httpGet = new HttpGet(new URL(query), true);
+        Subject.doAs(authorizedSubject, new PrivilegedExceptionAction<Object>() {
+            public Object run() throws Exception {
+                try {
+                    httpGet.prepare();
+                    Assert.assertEquals(httpGet.getResponseCode(), 200);
+                } catch (Exception e) {
+                    Assert.fail("authorized access should not throw exception");
+                }
+                return null;
+            }
+        });
+    }
+
+}

--- a/luskan/src/main/java/org/opencadc/luskan/LuskanConfig.java
+++ b/luskan/src/main/java/org/opencadc/luskan/LuskanConfig.java
@@ -78,7 +78,9 @@ import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import org.apache.log4j.Logger;
+import org.opencadc.gms.GroupURI;
 
 public class LuskanConfig {
     private static final Logger log = Logger.getLogger(LuskanConfig.class);
@@ -88,6 +90,7 @@ public class LuskanConfig {
     public static final String URI_KEY = LUSKAN_KEY + ".resourceID";
     public static final String TMPDIR_KEY = LUSKAN_KEY + ".resultsDir";
     public static final String STORAGE_SITE_KEY = LUSKAN_KEY + ".isStorageSite";
+    public static final String ALLOWED_GROUP = LUSKAN_KEY + ".allowedGroup";
 
     public LuskanConfig() {
 
@@ -168,6 +171,21 @@ public class LuskanConfig {
             sb.append("OK");
         }
         sb.append("\n");
+
+        List<String> allowedGroups = props.getProperty(ALLOWED_GROUP);
+        if (allowedGroups.isEmpty()) {
+            sb.append("MISSING");
+        } else {
+            for (String allowedGroup : allowedGroups) {
+                sb.append("\n\t").append(ALLOWED_GROUP).append(" - ").append(allowedGroup);
+                try {
+                    new GroupURI(URI.create(allowedGroup));
+                    sb.append(" OK");
+                } catch (IllegalArgumentException e) {
+                    sb.append(" INVALID GroupURI");
+                }
+            }
+        }
 
         if (!ok) {
             throw new IllegalStateException(sb.toString());

--- a/luskan/src/main/java/org/opencadc/luskan/LuskanConfig.java
+++ b/luskan/src/main/java/org/opencadc/luskan/LuskanConfig.java
@@ -175,6 +175,7 @@ public class LuskanConfig {
         List<String> allowedGroups = props.getProperty(ALLOWED_GROUP);
         if (allowedGroups.isEmpty()) {
             sb.append("MISSING");
+            ok = false;
         } else {
             for (String allowedGroup : allowedGroups) {
                 sb.append("\n\t").append(ALLOWED_GROUP).append(" - ").append(allowedGroup);
@@ -183,6 +184,7 @@ public class LuskanConfig {
                     sb.append(" OK");
                 } catch (IllegalArgumentException e) {
                     sb.append(" INVALID GroupURI");
+                    ok = false;
                 }
             }
         }

--- a/luskan/src/main/java/org/opencadc/luskan/QueryRunnerImpl.java
+++ b/luskan/src/main/java/org/opencadc/luskan/QueryRunnerImpl.java
@@ -86,15 +86,18 @@ public class QueryRunnerImpl extends QueryRunner {
     public QueryRunnerImpl() {
     }
 
-    @Override protected DataSource getUploadDataSource() throws Exception {
+    @Override
+    protected DataSource getUploadDataSource() throws Exception {
         return getQueryDataSource();
     }
 
-    @Override protected DataSource getTapSchemaDataSource() throws Exception {
+    @Override
+    protected DataSource getTapSchemaDataSource() throws Exception {
         return getQueryDataSource();
     }
 
-    @Override protected DataSource getQueryDataSource() throws Exception {
+    @Override
+    protected DataSource getQueryDataSource() throws Exception {
         log.debug("Data Source name: jdbc/tapuser");
         return DBUtil.findJNDIDataSource("jdbc/tapuser");
     }

--- a/luskan/src/main/java/org/opencadc/luskan/QueryRunnerImpl.java
+++ b/luskan/src/main/java/org/opencadc/luskan/QueryRunnerImpl.java
@@ -69,13 +69,24 @@
 
 package org.opencadc.luskan;
 
+import ca.nrc.cadc.cred.client.CredUtil;
 import ca.nrc.cadc.db.DBUtil;
+import ca.nrc.cadc.reg.Standards;
+import ca.nrc.cadc.reg.client.LocalAuthority;
 import ca.nrc.cadc.tap.QueryRunner;
+import ca.nrc.cadc.util.MultiValuedProperties;
 
+import java.net.URI;
+import java.security.AccessControlException;
+import java.security.cert.CertificateException;
+import java.util.ArrayList;
+import java.util.List;
 import javax.sql.DataSource;
 
 import org.apache.log4j.Logger;
-
+import org.opencadc.gms.GroupClient;
+import org.opencadc.gms.GroupURI;
+import org.opencadc.gms.GroupUtil;
 
 /**
  *
@@ -103,4 +114,48 @@ public class QueryRunnerImpl extends QueryRunner {
         log.debug("Data Source name: jdbc/tapuser");
         return DBUtil.findJNDIDataSource("jdbc/tapuser");
     }
+
+    /**
+     *
+     */
+    @Override
+    public void run() {
+        checkPermission();
+        super.run();
+    }
+
+    /**
+     *
+     */
+    private void checkPermission() {
+        try {
+            if (CredUtil.checkCredentials()) {
+                // better to get all the groups for the caller which could be a long list,
+                // or call isMember for each configured allowed group, which should be a short list.
+                // Or make it configurable.
+                LocalAuthority loc = new LocalAuthority();
+                URI resourceID = loc.getServiceURI(Standards.GMS_SEARCH_01.toString());
+                GroupClient client = GroupUtil.getGroupClient(resourceID);
+                List<GroupURI> memberships = client.getMemberships();
+
+                MultiValuedProperties props = LuskanConfig.getConfig();
+                List<String> configGroups = props.getProperty(LuskanConfig.ALLOWED_GROUP);
+                List<GroupURI> allowedGroups = new ArrayList<>();
+                configGroups.forEach(group -> allowedGroups.add(new GroupURI(URI.create(group))));
+
+                for (GroupURI memberGroup : memberships) {
+                    for (GroupURI allowedGroup : allowedGroups) {
+                        if (memberGroup.equals(allowedGroup)) {
+                            log.debug("Allowed group: " + allowedGroup);
+                            return;
+                        }
+                    }
+                }
+            }
+        } catch (CertificateException e) {
+            throw new AccessControlException("read permission denied (invalid delegated client certificate)");
+        }
+        throw new AccessControlException("permission denied");
+    }
+
 }


### PR DESCRIPTION
Updated the `QueryRunnerImpl` in Luskan to override the `QueryRunner` run() method. run() in `QueryRunnerImpl` first calls checkPermission() to see if the caller is authorized, throwing an AccessControlException if the user is not authorized. If the user is authorized calls the `QueryRunner` run() method to do the query.
checkPermission() gets a list of groups the calling user is a member of. Then gets the list of a groups allowed to query luskan from the `org.opencadc.luskan.allowGroup` property in `luskan.properties`. Lastly compares the users groups with the allowed groups looking for a match.