### PR TITLE
implement lock using select for update

### DIFF
--- a/cadc-inventory-db/build.gradle
+++ b/cadc-inventory-db/build.gradle
@@ -17,7 +17,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '0.12.2'
+version = '0.13.0'
 
 description = 'OpenCADC Storage Inventory database library'
 def git_url = 'https://github.com/opencadc/storage-inventory'

--- a/cadc-inventory-db/src/main/java/org/opencadc/inventory/db/ArtifactDAO.java
+++ b/cadc-inventory-db/src/main/java/org/opencadc/inventory/db/ArtifactDAO.java
@@ -131,6 +131,10 @@ public class ArtifactDAO extends AbstractDAO<Artifact> {
         super.delete(Artifact.class, id);
     }
     
+    public Artifact lock(UUID id) {
+        return super.lock(Artifact.class, id);
+    }
+    
     public void setStorageLocation(Artifact a, StorageLocation loc) {
         if (!origin) {
             throw new IllegalStateException("cannot update Artifact.storageLocation with origin=false");

--- a/cadc-inventory-db/src/main/java/org/opencadc/inventory/db/SQLGenerator.java
+++ b/cadc-inventory-db/src/main/java/org/opencadc/inventory/db/SQLGenerator.java
@@ -3,7 +3,7 @@
 *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 *
-*  (c) 2020.                            (c) 2020.
+*  (c) 2022.                            (c) 2022.
 *  Government of Canada                 Gouvernement du Canada
 *  National Research Council            Conseil national de recherches
 *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -219,12 +219,21 @@ public class SQLGenerator {
     }
     
     public EntityGet<? extends Entity> getEntityGet(Class c) {
+        return getEntityGet(c, false);
+    }
+    
+    public EntityGet<? extends Entity> getEntityGet(Class c, boolean forUpdate) {
         if (Artifact.class.equals(c)) {
-            return new ArtifactGet();
+            return new ArtifactGet(forUpdate);
         }
         if (StorageSite.class.equals(c)) {
-            return new StorageSiteGet();
+            return new StorageSiteGet(forUpdate);
         }
+        
+        if (forUpdate) {
+            throw new UnsupportedOperationException("entity-get + forUpdate: " + c.getSimpleName());
+        }
+        
         if (DeletedArtifactEvent.class.equals(c)) {
             return new DeletedArtifactEventGet();
         }
@@ -491,7 +500,12 @@ public class SQLGenerator {
     class ArtifactGet implements EntityGet<Artifact> {
         private UUID id;
         private URI uri;
-
+        private final boolean forUpdate;
+        
+        ArtifactGet(boolean forUpdate) {
+            this.forUpdate = forUpdate;
+        }
+        
         @Override
         public void setID(UUID id) {
             this.id = id;
@@ -516,6 +530,9 @@ public class SQLGenerator {
             } else {
                 String col = getKeyColumn(Artifact.class, false);
                 sb.append(col).append(" = ?");
+            }
+            if (forUpdate) {
+                sb.append(" FOR UPDATE");
             }
             String sql = sb.toString();
             log.debug("ArtifactGet: " + sql);
@@ -666,7 +683,12 @@ public class SQLGenerator {
     private class StorageSiteGet implements EntityGet<StorageSite> {
         private UUID id;
         private URI uri;
+        private final boolean forUpdate;
 
+        public StorageSiteGet(boolean forUpdate) {
+            this.forUpdate = forUpdate;
+        }
+        
         @Override
         public void setID(UUID id) {
             this.id = id;

--- a/critwall/build.gradle
+++ b/critwall/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     compile 'org.opencadc:cadc-storage-adapter:[0.8,1.0)'
     compile 'org.opencadc:cadc-util:[1.5.3,2.0)'
     compile 'org.opencadc:cadc-inventory:[0.7,2.0)'
-    compile 'org.opencadc:cadc-inventory-db:[0.9.1,1.0)'
+    compile 'org.opencadc:cadc-inventory-db:[0.13,1.0)'
     compile 'org.opencadc:cadc-inventory-util:[0.1.1,1.0)'
     compile 'org.opencadc:cadc-registry:[1.5,2.0)'
     compile 'org.opencadc:cadc-vosi:[1.3.6,2.0)'

--- a/critwall/src/main/java/org/opencadc/critwall/FileSyncJob.java
+++ b/critwall/src/main/java/org/opencadc/critwall/FileSyncJob.java
@@ -247,8 +247,7 @@ public class FileSyncJob implements Runnable {
                             txnMgr.startTransaction();
                             log.debug("start txn: OK");
                             
-                            artifactDAO.lock(artifact);
-                            curArtifact = artifactDAO.get(artifactID);
+                            curArtifact = artifactDAO.lock(artifact);
                             
                             ObsoleteStorageLocation prevOSL = locDAO.get(storageMeta.getStorageLocation());
                             if (prevOSL != null) {

--- a/fenwick/build.gradle
+++ b/fenwick/build.gradle
@@ -16,9 +16,8 @@ group = 'org.opencadc'
 
 dependencies {
     compile 'log4j:log4j:[1.2,)'
-    compile 'org.opencadc:cadc-storage-adapter:[0.3,1.0)'
     compile 'org.opencadc:cadc-util:[1.3.21,2.0)'
-    compile 'org.opencadc:cadc-inventory-db:[0.10,1.0)'
+    compile 'org.opencadc:cadc-inventory-db:[0.13,1.0)'
     compile 'org.opencadc:cadc-inventory-util:[0.1.2,1.0)'
     compile 'org.opencadc:cadc-registry:[1.5,2.0)'
     compile 'org.opencadc:cadc-tap:[1.1.1,1.2)' // 1.2 upper bound is correct #reasons

--- a/minoc/build.gradle
+++ b/minoc/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     compile 'org.opencadc:cadc-data-ops-fits:[0.2.4,)'
     compile 'org.opencadc:cadc-gms:[1.0.0,)'
     compile 'org.opencadc:cadc-inventory:[0.8.5,)'
-    compile 'org.opencadc:cadc-inventory-db:[0.10.1,)'
+    compile 'org.opencadc:cadc-inventory-db:[0.13.0,1.0)'
     compile 'org.opencadc:cadc-inventory-server:[0.1.2,)'
     compile 'org.opencadc:cadc-soda-server:[1.2.0,2.0.0)'
     compile 'org.opencadc:cadc-storage-adapter:[0.8,)'

--- a/minoc/src/main/java/org/opencadc/minoc/DeleteAction.java
+++ b/minoc/src/main/java/org/opencadc/minoc/DeleteAction.java
@@ -126,7 +126,7 @@ public class DeleteAction extends ArtifactAction {
             
             boolean locked = false;
             while (existing != null && !locked) {
-                existing = artifactDAO.getWithLock(existing);
+                existing = artifactDAO.lock(existing);
                 if (existing != null) {
                     locked = true;
                 } else {

--- a/minoc/src/main/java/org/opencadc/minoc/DeleteAction.java
+++ b/minoc/src/main/java/org/opencadc/minoc/DeleteAction.java
@@ -126,11 +126,11 @@ public class DeleteAction extends ArtifactAction {
             
             boolean locked = false;
             while (existing != null && !locked) {
-                try { 
-                    artifactDAO.lock(existing);
+                existing = artifactDAO.getWithLock(existing);
+                if (existing != null) {
                     locked = true;
-                } catch (EntityNotFoundException ex) {
-                    // entity deleted
+                } else {
+                    // try again by uri
                     existing = artifactDAO.get(artifactURI);
                 }
             }

--- a/minoc/src/main/java/org/opencadc/minoc/PostAction.java
+++ b/minoc/src/main/java/org/opencadc/minoc/PostAction.java
@@ -125,7 +125,7 @@ public class PostAction extends ArtifactAction {
             
             boolean locked = false;
             while (existing != null && !locked) {
-                existing = artifactDAO.getWithLock(existing);
+                existing = artifactDAO.lock(existing);
                 profiler.checkpoint("artifactDAO.lock.ok");
                 if (existing != null) {
                     locked = true;

--- a/minoc/src/main/java/org/opencadc/minoc/PostAction.java
+++ b/minoc/src/main/java/org/opencadc/minoc/PostAction.java
@@ -125,13 +125,13 @@ public class PostAction extends ArtifactAction {
             
             boolean locked = false;
             while (existing != null && !locked) {
-                try { 
-                    artifactDAO.lock(existing);
-                    profiler.checkpoint("artifactDAO.lock.ok");
+                existing = artifactDAO.getWithLock(existing);
+                profiler.checkpoint("artifactDAO.lock.ok");
+                if (existing != null) {
                     locked = true;
-                } catch (EntityNotFoundException ex) {
+                } else {
                     profiler.checkpoint("artifactDAO.lock.fail");
-                    // entity deleted
+                    // try again via uri
                     existing = artifactDAO.get(artifactURI);
                     profiler.checkpoint("artifactDAO.get.ok");
                 }

--- a/minoc/src/main/java/org/opencadc/minoc/PutAction.java
+++ b/minoc/src/main/java/org/opencadc/minoc/PutAction.java
@@ -225,7 +225,7 @@ public class PutAction extends ArtifactAction {
             
             boolean locked = false;
             while (existing != null && !locked) {
-                existing = artifactDAO.getWithLock(existing);
+                existing = artifactDAO.lock(existing);
                 profiler.checkpoint("artifactDAO.lock.ok");
                 if (existing != null) {
                     locked = true;

--- a/minoc/src/main/java/org/opencadc/minoc/PutAction.java
+++ b/minoc/src/main/java/org/opencadc/minoc/PutAction.java
@@ -225,13 +225,13 @@ public class PutAction extends ArtifactAction {
             
             boolean locked = false;
             while (existing != null && !locked) {
-                try { 
-                    artifactDAO.lock(existing);
-                    profiler.checkpoint("artifactDAO.lock.ok");
+                existing = artifactDAO.getWithLock(existing);
+                profiler.checkpoint("artifactDAO.lock.ok");
+                if (existing != null) {
                     locked = true;
-                } catch (EntityNotFoundException ex) {
+                } else {
                     profiler.checkpoint("artifactDAO.lock.fail");
-                    // entity deleted
+                    // try again via uri
                     existing = artifactDAO.get(artifactURI);
                     profiler.checkpoint("artifactDAO.get.ok");
                 }

--- a/ratik/build.gradle
+++ b/ratik/build.gradle
@@ -16,9 +16,8 @@ group = 'org.opencadc'
 
 dependencies {
     compile 'log4j:log4j:[1.2,)'
-    compile 'org.opencadc:cadc-storage-adapter:[0.3,1.0)'
     compile 'org.opencadc:cadc-util:[1.3.12,2.0)'
-    compile 'org.opencadc:cadc-inventory-db:[0.12.0,1.0)'
+    compile 'org.opencadc:cadc-inventory-db:[0.13,1.0)'
     compile 'org.opencadc:cadc-inventory-util:[0.1.4,1.0)'
     compile 'org.opencadc:cadc-registry:[1.5,2.0)'
     compile 'org.opencadc:cadc-tap:[1.1.6,2.0)'

--- a/ringhold/build.gradle
+++ b/ringhold/build.gradle
@@ -17,7 +17,7 @@ group = 'org.opencadc'
 dependencies {
     compile 'log4j:log4j:[1.2,)'
     compile 'org.opencadc:cadc-util:[1.3.12,2.0)'
-    compile 'org.opencadc:cadc-inventory-db:[0.11.1,1.0)'
+    compile 'org.opencadc:cadc-inventory-db:[0.13,1.0)'
 
     testCompile 'junit:junit:[4.12,5.0)'
 }

--- a/tantar/build.gradle
+++ b/tantar/build.gradle
@@ -16,7 +16,7 @@ group = 'org.opencadc'
 
 dependencies {
     compile 'log4j:log4j:[1.2,)'
-    compile 'org.opencadc:cadc-inventory-db:[0.10.1,1.0)'
+    compile 'org.opencadc:cadc-inventory-db:[0.13,1.0)'
     compile 'org.opencadc:cadc-log:[1.1.2,2.0)'
     compile 'org.opencadc:cadc-util:[1.3,2.0)'
     compile 'org.opencadc:cadc-inventory-util:[0.1.0,1.0)'


### PR DESCRIPTION
ArtifactDAO.lock(...) now returns Artifact or null and no longer throws EntityNotFoundException

in some code, this leads to a questionable construct like
```
start transaction
cur = lock(...)
if (cur != null)
  do stuff
  commit
else
  rollback
```
It's probably ok to always commit (to release the lock) but it isn't clear if that has the same result in detail (in the db); Apps used to rollback in response to EntityNotFoundException and the above sort of code stays with that approach for now.