### PR TITLE
minoc: set content-length-0 after POST

### DIFF
--- a/minoc/build.gradle
+++ b/minoc/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     compile 'org.opencadc:cadc-gms:[1.0,)'
     
     compile 'org.opencadc:nom-tam-fits:1.16.4'
+    compile 'org.opencadc:cadc-data-ops-fits:0.2.5'
 
     testCompile 'junit:junit:[4.0,)'
     testCompile 'org.opencadc:cadc-storage-adapter-fs:[0.8.3,)'

--- a/minoc/src/main/java/org/opencadc/minoc/PostAction.java
+++ b/minoc/src/main/java/org/opencadc/minoc/PostAction.java
@@ -193,6 +193,7 @@ public class PostAction extends ArtifactAction {
             
             syncOutput.setCode(202); // Accepted
             HeadAction.setHeaders(existing, syncOutput);
+            syncOutput.setHeader("content-length", 0);
         } catch (Exception e) {
             log.error("failed to persist " + artifactURI, e);
             txnMgr.rollbackTransaction();


### PR DESCRIPTION
pinned to older versions of fits ops to keep striding test working