### PR TITLE
fenwick: bug fix for incorrectly retained values during resolve-collision

### DIFF
--- a/fenwick/src/main/java/org/opencadc/fenwick/ArtifactSync.java
+++ b/fenwick/src/main/java/org/opencadc/fenwick/ArtifactSync.java
@@ -244,6 +244,7 @@ public class ArtifactSync extends AbstractSync {
                                     + " contentLastModified=" + df.format(currentArtifact.getContentLastModified())
                                     + " reason=resolve-collision");
                             artifactDAO.delete(currentArtifact.getID());
+                            currentArtifact = null;
                         } else {
                             log.info("ArtifactSync.skipArtifact id=" + artifact.getID() 
                                     + " uri=" + artifact.getURI() 


### PR DESCRIPTION
local siteLocations (global) or storageLocation (site) could be retained in resolve-collision in favour of remote artifact