### PR TITLE
Support stream cutouts for large FZ (compressed) files

### DIFF
--- a/minoc/Dockerfile
+++ b/minoc/Dockerfile
@@ -1,4 +1,4 @@
-FROM cadc-tomcat
+FROM cadc-tomcat:1
 
 RUN dnf install -y wcslib && dnf clean all
 

--- a/minoc/Dockerfile
+++ b/minoc/Dockerfile
@@ -1,4 +1,4 @@
-FROM cadc-tomcat:1
+FROM cadc-tomcat
 
 RUN dnf install -y wcslib && dnf clean all
 

--- a/minoc/build.gradle
+++ b/minoc/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     compile 'org.opencadc:cadc-vosi:[1.4.3,2.0)'
     compile 'org.opencadc:cadc-rest:[1.3.10,)'
     compile 'org.opencadc:cadc-cdp:[1.0,)'
-    compile 'org.opencadc:cadc-data-ops-fits:[0.2.4,)'
+    compile 'org.opencadc:cadc-data-ops-fits:[0.2.7,)'
     compile 'org.opencadc:cadc-gms:[1.0.0,)'
     compile 'org.opencadc:cadc-inventory:[0.9,2.0)'
     compile 'org.opencadc:cadc-inventory-db:[0.14,1.0)'
@@ -40,8 +40,7 @@ dependencies {
     compile 'org.opencadc:cadc-permissions-client:[0.2,)'
     compile 'org.opencadc:cadc-gms:[1.0,)'
     
-    compile 'org.opencadc:nom-tam-fits:1.16.4'
-    compile 'org.opencadc:cadc-data-ops-fits:0.2.5'
+    compile 'org.opencadc:nom-tam-fits:1.16.6'
 
     testCompile 'junit:junit:[4.0,)'
     testCompile 'org.opencadc:cadc-storage-adapter-fs:[0.8.3,)'

--- a/minoc/src/intTest/java/org/opencadc/minoc/FitsOperationsTest.java
+++ b/minoc/src/intTest/java/org/opencadc/minoc/FitsOperationsTest.java
@@ -145,6 +145,18 @@ public class FitsOperationsTest extends MinocTest {
     }
 
     @Test
+    public void testLargeCompressed() throws Exception {
+        final String testFilePrefix = "test-cfht";
+        final String testFileExtension = "fz";
+        final URI artifactURI = URI.create("cadc:TEST/" + testFilePrefix + "." + testFileExtension);
+        final String[] cutoutSpecs = new String[] {
+                "[2][*:20]"
+        };
+
+        uploadAndCompareCutout(artifactURI, SodaParamValidator.SUB, cutoutSpecs, testFilePrefix, "fits");
+    }
+
+    @Test
     public void testSimple() throws Exception {
         final String testFilePrefix = "test-simple";
         final String testFileExtension = "fits";
@@ -399,7 +411,8 @@ public class FitsOperationsTest extends MinocTest {
             final HttpDelete del = new HttpDelete(artifactURL, false);
             del.run();
             final Throwable throwable = del.getThrowable();
-            if (throwable != null && !(throwable instanceof ResourceNotFoundException)) {
+            if (throwable != null && !(throwable instanceof ResourceNotFoundException)
+                && !(throwable instanceof IllegalStateException)) {
                 Assert.fail(throwable.getMessage());
             }
 


### PR DESCRIPTION
Add integration test with 310MB `test-cfht.fz` file.  Requires `opencadc:nom-tam-fits:1.16.6`.