### PR TITLE
SwiftStorageAdapter: add rgw exception handling in iterators

### DIFF
--- a/cadc-storage-adapter-swift/build.gradle
+++ b/cadc-storage-adapter-swift/build.gradle
@@ -14,7 +14,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '0.8.2'
+version = '0.8.3'
 
 apply from: '../opencadc.gradle'
 

--- a/cadc-storage-adapter-swift/build.gradle
+++ b/cadc-storage-adapter-swift/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     compile 'org.apache.commons:commons-pool2:[2.9,3.0)'
     compile 'org.opencadc:cadc-util:[1.6,2.0)'
     compile 'org.opencadc:cadc-inventory:[0.7,)'
-    compile 'org.opencadc:cadc-storage-adapter:[0.11,)'
+    compile 'org.opencadc:cadc-storage-adapter:[0.11.1,)'
 
     // swift API
     compile 'org.opencadc:joss:0.10.4-pdowler1'

--- a/cadc-storage-adapter-swift/src/main/java/org/opencadc/inventory/storage/swift/SwiftStorageAdapter.java
+++ b/cadc-storage-adapter-swift/src/main/java/org/opencadc/inventory/storage/swift/SwiftStorageAdapter.java
@@ -1244,10 +1244,11 @@ public class SwiftStorageAdapter  implements StorageAdapter {
             return false;
         } catch (CommandException ex) {
             if (ex.getHttpStatusCode() > 500) {
+                retryCount++;
                 if (retryCount <= 3) {
                     try {
                         Thread.sleep(retryCount * 2000L);
-                        return isIteratorVisible(obj, includeRecoverable, retryCount++);
+                        return isIteratorVisible(obj, includeRecoverable, retryCount);
                     } catch (InterruptedException iex) {
                         log.debug("isIteratorVisible sleep-before-retry interrupted", iex);
                         // continue to throw below

--- a/cadc-storage-adapter/build.gradle
+++ b/cadc-storage-adapter/build.gradle
@@ -14,7 +14,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '0.11.0'
+version = '0.11.1'
 
 description = 'OpenCADC Storage Inventory StorageAdapter API library'
 def git_url = 'https://github.com/opencadc/storage-inventory'

--- a/cadc-storage-adapter/src/main/java/org/opencadc/inventory/storage/StorageEngageException.java
+++ b/cadc-storage-adapter/src/main/java/org/opencadc/inventory/storage/StorageEngageException.java
@@ -3,7 +3,7 @@
  *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
  **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
  *
- *  (c) 2019.                            (c) 2019.
+ *  (c) 2022.                            (c) 2022.
  *  Government of Canada                 Gouvernement du Canada
  *  National Research Council            Conseil national de recherches
  *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -69,12 +69,14 @@ package org.opencadc.inventory.storage;
 
 /**
  * This exception indicates that the storage adapter failed
- * to connect to or interact with its storage system.
+ * to connect to or interact with its storage system. This
+ * was changed to unchecked (RuntimeException) so it can be thrown
+ * from iterator methods.
  * 
  * @author majorb
  */
 @SuppressWarnings("serial")
-public class StorageEngageException extends Exception {
+public class StorageEngageException extends RuntimeException {
 
     /**
      * Construct an exception.

--- a/tantar/build.gradle
+++ b/tantar/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 
     runtime 'org.opencadc:cadc-storage-adapter-fs:[0.9.1,)'
     runtime 'org.opencadc:cadc-storage-adapter-ad:[0.5.5,)'
-    runtime 'org.opencadc:cadc-storage-adapter-swift:[0.8.2,)'
+    runtime 'org.opencadc:cadc-storage-adapter-swift:[0.8.3,)'
 
     testCompile 'junit:junit:[4.12,5.0)'
 

--- a/tantar/build.gradle
+++ b/tantar/build.gradle
@@ -24,11 +24,11 @@ dependencies {
     compile 'org.opencadc:cadc-inventory:[0.9,2.0)'
     compile 'org.opencadc:cadc-inventory-db:[0.14,1.0)'
     compile 'org.opencadc:cadc-inventory-util:[0.1.8,1.0)'
-    compile 'org.opencadc:cadc-storage-adapter:[0.8,1.0)'
+    compile 'org.opencadc:cadc-storage-adapter:[0.11.1,1.0)'
 
     runtime 'org.opencadc:cadc-storage-adapter-fs:[0.9.1,)'
     runtime 'org.opencadc:cadc-storage-adapter-ad:[0.5.5,)'
-    runtime 'org.opencadc:cadc-storage-adapter-swift:[0.8.1,)'
+    runtime 'org.opencadc:cadc-storage-adapter-swift:[0.8.2,)'
 
     testCompile 'junit:junit:[4.12,5.0)'
 


### PR DESCRIPTION
dealing with these two fails:
```
org.javaswift.joss.exception.NotFoundException: null
        ...
        at org.javaswift.joss.client.core.AbstractObjectStoreEntity.getMetadata(AbstractObjectStoreEntity.java:71) ~[joss-0.10.4-pdowler1.jar:?]
        at org.opencadc.inventory.storage.swift.SwiftStorageAdapter.isIteratorVisible(SwiftStorageAdapter.java:1220) ~[cadc-storage-adapter-swift-0.8.2.jar:?]
```

And in this one I didn't capture the actual status code but it's a 504.
```
2022-12-03 20:13:53.421[main] FATAL Main - null
org.javaswift.joss.exception.CommandException: null
        at org.javaswift.joss.command.impl.core.httpstatus.HttpStatusChecker.verifyCode(HttpStatusChecker.java:45) ~[joss-0.10.4-pdowler1.jar:?]
...
at org.javaswift.joss.client.core.AbstractObjectStoreEntity.getMetadata(AbstractObjectStoreEntity.java:71) ~[joss-0.10.4-pdowler1.jar:?]
        at org.opencadc.inventory.storage.swift.SwiftStorageAdapter.isIteratorVisible(SwiftStorageAdapter.java:1220) ~[cadc-storage-adapter-swift-0.8.2.jar:?]
```