### PR TITLE
fenwick: add tweak to update DeletedArtifactEvent.lastModified

### DIFF
--- a/cadc-inventory-db/build.gradle
+++ b/cadc-inventory-db/build.gradle
@@ -17,7 +17,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '0.14.3'
+version = '0.14.4'
 
 description = 'OpenCADC Storage Inventory database library'
 def git_url = 'https://github.com/opencadc/storage-inventory'

--- a/cadc-inventory-db/src/intTest/java/org/opencadc/inventory/db/EntityEventDAOTest.java
+++ b/cadc-inventory-db/src/intTest/java/org/opencadc/inventory/db/EntityEventDAOTest.java
@@ -3,7 +3,7 @@
 *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 *
-*  (c) 2019.                            (c) 2019.
+*  (c) 2022.                            (c) 2022.
 *  Government of Canada                 Gouvernement du Canada
 *  National Research Council            Conseil national de recherches
 *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -73,6 +73,7 @@ import ca.nrc.cadc.db.DBUtil;
 import ca.nrc.cadc.util.Log4jInit;
 import java.net.URI;
 import java.security.MessageDigest;
+import java.util.Date;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.UUID;
@@ -171,6 +172,13 @@ public class EntityEventDAOTest {
             Assert.assertNotNull(fid2);
             // idempotent includes not updating timestamp
             Assert.assertEquals("lastModified", expected.getLastModified(), fid2.getLastModified());
+            
+            // global: force timestamp update
+            Thread.sleep(10L);
+            daeDAO.put(fid, true);
+            DeletedArtifactEvent fid3 = (DeletedArtifactEvent) daeDAO.get(expected.getID());
+            Assert.assertNotNull(fid3);
+            Assert.assertTrue("lastModified", expected.getLastModified().before(fid3.getLastModified()));
             
             // no delete
         } catch (Exception unexpected) {

--- a/cadc-inventory-db/src/intTest/java/org/opencadc/inventory/db/EntityEventDAOTest.java
+++ b/cadc-inventory-db/src/intTest/java/org/opencadc/inventory/db/EntityEventDAOTest.java
@@ -207,7 +207,7 @@ public class EntityEventDAOTest {
             
             Assert.assertTrue("lastModified", fid.getLastModified().after(now));
             
-            // idempotent put: create new instance with same state
+            // idempotent put: put again, try to force, but no update
             Thread.sleep(10L);
             daeDAO.put(fid, true);
             

--- a/cadc-inventory-db/src/main/java/org/opencadc/inventory/db/DeletedArtifactEventDAO.java
+++ b/cadc-inventory-db/src/main/java/org/opencadc/inventory/db/DeletedArtifactEventDAO.java
@@ -91,4 +91,10 @@ public class DeletedArtifactEventDAO extends AbstractDAO<DeletedArtifactEvent> {
     public DeletedArtifactEvent get(UUID id) {
         return super.get(DeletedArtifactEvent.class, id);
     }
+
+    public void put(DeletedArtifactEvent val, boolean timestampUpdate) {
+        super.put(val, false, timestampUpdate);
+    }
+    
+    
 }

--- a/cadc-inventory-db/src/main/java/org/opencadc/inventory/db/DeletedArtifactEventDAO.java
+++ b/cadc-inventory-db/src/main/java/org/opencadc/inventory/db/DeletedArtifactEventDAO.java
@@ -93,7 +93,7 @@ public class DeletedArtifactEventDAO extends AbstractDAO<DeletedArtifactEvent> {
     }
 
     public void put(DeletedArtifactEvent val, boolean timestampUpdate) {
-        super.put(val, false, timestampUpdate);
+        super.put(val, false, false, true);
     }
     
     

--- a/fenwick/build.gradle
+++ b/fenwick/build.gradle
@@ -17,7 +17,7 @@ group = 'org.opencadc'
 dependencies {
     compile 'org.opencadc:cadc-util:[1.6,2.0)'
     compile 'org.opencadc:cadc-inventory:[0.9,2.0)'
-    compile 'org.opencadc:cadc-inventory-db:[0.14.3,2.0)'
+    compile 'org.opencadc:cadc-inventory-db:[0.14.4,2.0)'
     compile 'org.opencadc:cadc-inventory-util:[0.1.8,1.0)'
     compile 'org.opencadc:cadc-registry:[1.5,2.0)'
     compile 'org.opencadc:cadc-tap:[1.1.14,1.2)' // 1.2 upper bound is correct #reasons

--- a/fenwick/src/intTest/java/org/opencadc/fenwick/DeletedArtifactEventSyncTest.java
+++ b/fenwick/src/intTest/java/org/opencadc/fenwick/DeletedArtifactEventSyncTest.java
@@ -121,7 +121,7 @@ public class DeletedArtifactEventSyncTest {
         try {
             log.info("testGetEventStream");
             DeletedArtifactEventSync sync = 
-                    new DeletedArtifactEventSync(inventoryEnvironment.artifactDAO, TestUtil.LUSKAN_URI, 6, 6);
+                    new DeletedArtifactEventSync(inventoryEnvironment.artifactDAO, TestUtil.LUSKAN_URI, false, 6, 6);
             Subject.doAs(testUser, new PrivilegedExceptionAction<Object>() {
 
                 public Object run() throws Exception {
@@ -189,7 +189,7 @@ public class DeletedArtifactEventSyncTest {
             Thread.sleep(10L);
             
             // doit
-            DeletedArtifactEventSync sync = new DeletedArtifactEventSync(inventoryEnvironment.artifactDAO, TestUtil.LUSKAN_URI, 6, 6);
+            DeletedArtifactEventSync sync = new DeletedArtifactEventSync(inventoryEnvironment.artifactDAO, TestUtil.LUSKAN_URI, false, 6, 6);
             sync.enableSkipOldEvents = false;
             Subject.doAs(this.testUser, (PrivilegedExceptionAction<Object>) () -> {
                 sync.doit();

--- a/fenwick/src/main/java/org/opencadc/fenwick/InventoryHarvester.java
+++ b/fenwick/src/main/java/org/opencadc/fenwick/InventoryHarvester.java
@@ -218,7 +218,7 @@ public class InventoryHarvester implements Runnable {
                 threads.add(createThread("sle-thread", r3));
             }
             
-            AbstractSync r1 = new DeletedArtifactEventSync(daeArtifactDAO, resourceID, SYNC_SLEEP, maxRetryInterval);
+            AbstractSync r1 = new DeletedArtifactEventSync(daeArtifactDAO, resourceID, trackSiteLocations, SYNC_SLEEP, maxRetryInterval);
             tasks.add(r1);
             threads.add(createThread("dae-thread", r1));
             


### PR DESCRIPTION
update when event first reaches global so incremental harvest sequence works as expected