### PR TITLE
CADC-12278 make availability checks work without LocalAuthority or auth cert

### DIFF
--- a/luskan/VERSION
+++ b/luskan/VERSION
@@ -1,6 +1,6 @@
 ## deployable containers have a semantic and build tag
 # semantic version tag: major.minor
 # build version tag: timestamp
-VER=0.6.1
+VER=0.6.2
 TAGS="${VER} ${VER}-$(date --utc +"%Y%m%dT%H%M%S")"
 unset VER

--- a/minoc/VERSION
+++ b/minoc/VERSION
@@ -4,6 +4,6 @@
 # tags with and without build number so operators use the versioned
 # tag but we always keep a timestamped tag in case a semantic tag gets
 # replaced accidentally
-VER=0.9.3
+VER=0.9.4
 TAGS="${VER} ${VER}-$(date --utc +"%Y%m%dT%H%M%S")"
 unset VER

--- a/minoc/src/main/java/org/opencadc/minoc/ServiceAvailability.java
+++ b/minoc/src/main/java/org/opencadc/minoc/ServiceAvailability.java
@@ -98,7 +98,7 @@ import org.opencadc.inventory.db.ArtifactDAO;
 public class ServiceAvailability implements AvailabilityPlugin {
 
     private static final Logger log = Logger.getLogger(ServiceAvailability.class);
-    private static final File SERVOPS_PEM_FILE = new File(System.getProperty("user.home") + "/.ssl/cadcproxy.pem");
+    private static final File AAI_PEM_FILE = new File(System.getProperty("user.home") + "/.ssl/cadcproxy.pem");
     
     private String appName;
 
@@ -188,11 +188,15 @@ public class ServiceAvailability implements AvailabilityPlugin {
             } catch (NoSuchElementException ex) {
                 log.debug("not configured: " + Standards.GMS_SEARCH_10);
             }
-            
-            if (credURI != null || usersURI != null || groupsURI != null) {
-                // check for a certficate needed to perform network A&A ops
-                CheckCertificate checkCert = new CheckCertificate(SERVOPS_PEM_FILE);
-                checkCert.check();
+
+            if (credURI != null || usersURI != null) {
+                if (AAI_PEM_FILE.exists() && AAI_PEM_FILE.canRead()) {
+                    // check for a certificate needed to perform network A&A ops
+                    CheckCertificate checkCert = new CheckCertificate(AAI_PEM_FILE);
+                    checkCert.check();
+                } else {
+                    log.debug("AAI cert not found or unreadable");
+                }
             }
             
         } catch (CheckException ce) {

--- a/raven/VERSION
+++ b/raven/VERSION
@@ -2,6 +2,6 @@
 # semantic version tag: major.minor[.patch]
 # build version tag: timestamp
 # tag: {semantic}-{build}
-VER=0.7.2
+VER=0.7.3
 TAGS="${VER} ${VER}-$(date --utc +"%Y%m%dT%H%M%S")"
 unset VER 

--- a/raven/src/main/java/org/opencadc/raven/ServiceAvailability.java
+++ b/raven/src/main/java/org/opencadc/raven/ServiceAvailability.java
@@ -80,6 +80,7 @@ import ca.nrc.cadc.vosi.avail.CheckWebService;
 import java.io.File;
 import java.net.URI;
 import java.net.URL;
+import java.util.NoSuchElementException;
 import org.apache.log4j.Logger;
 
 /**
@@ -91,7 +92,7 @@ import org.apache.log4j.Logger;
 public class ServiceAvailability implements AvailabilityPlugin {
 
     private static final Logger log = Logger.getLogger(ServiceAvailability.class);
-    private static final File SERVOPS_PEM_FILE = new File(System.getProperty("user.home") + "/.ssl/cadcproxy.pem");
+    private static final File AAI_PEM_FILE = new File(System.getProperty("user.home") + "/.ssl/cadcproxy.pem");
     
     /**
      * Default, no-arg constructor.
@@ -127,33 +128,50 @@ public class ServiceAvailability implements AvailabilityPlugin {
         String note = "service is accepting requests";
         
         try {
-            // check for a certficate needed to perform network ops
-            CheckCertificate checkCert = new CheckCertificate(SERVOPS_PEM_FILE);
-            checkCert.check();
-            log.info("cert check ok");
-
             // check other services we depend on
             RegistryClient reg = new RegistryClient();
-            URL url;
-            CheckResource checkResource;
-            
             LocalAuthority localAuthority = new LocalAuthority();
 
-            URI credURI = localAuthority.getServiceURI(Standards.CRED_PROXY_10.toString());
-            url = reg.getServiceURL(credURI, Standards.VOSI_AVAILABILITY, AuthMethod.ANON);
-            checkResource = new CheckWebService(url);
-            checkResource.check();
-
-            URI usersURI = localAuthority.getServiceURI(Standards.UMS_USERS_01.toString());
-            url = reg.getServiceURL(usersURI, Standards.VOSI_AVAILABILITY, AuthMethod.ANON);
-            checkResource = new CheckWebService(url);
-            checkResource.check();
-            
-            URI groupsURI = localAuthority.getServiceURI(Standards.GMS_SEARCH_01.toString());
-            if (!groupsURI.equals(usersURI)) {
-                url = reg.getServiceURL(groupsURI, Standards.VOSI_AVAILABILITY, AuthMethod.ANON);
-                checkResource = new CheckWebService(url);
+            URI credURI = null;
+            try {
+                credURI = localAuthority.getServiceURI(Standards.CRED_PROXY_10.toString());
+                URL url = reg.getServiceURL(credURI, Standards.VOSI_AVAILABILITY, AuthMethod.ANON);
+                CheckResource checkResource = new CheckWebService(url);
                 checkResource.check();
+            } catch (NoSuchElementException ex) {
+                log.debug("not configured: " + Standards.CRED_PROXY_10);
+            }
+
+            URI usersURI = null;
+            try {
+                usersURI = localAuthority.getServiceURI(Standards.UMS_USERS_01.toString());
+                URL url = reg.getServiceURL(usersURI, Standards.VOSI_AVAILABILITY, AuthMethod.ANON);
+                CheckResource checkResource = new CheckWebService(url);
+                checkResource.check();
+            } catch (NoSuchElementException ex) {
+                log.debug("not configured: " + Standards.CRED_PROXY_10);
+            }
+
+            URI groupsURI = null;
+            try {
+                groupsURI = localAuthority.getServiceURI(Standards.GMS_SEARCH_01.toString());
+                if (!groupsURI.equals(usersURI)) {
+                    URL url = reg.getServiceURL(groupsURI, Standards.VOSI_AVAILABILITY, AuthMethod.ANON);
+                    CheckResource checkResource = new CheckWebService(url);
+                    checkResource.check();
+                }
+            } catch (NoSuchElementException ex) {
+                log.debug("not configured: " + Standards.CRED_PROXY_10);
+            }
+
+            if (credURI != null || usersURI != null) {
+                if (AAI_PEM_FILE.exists() && AAI_PEM_FILE.canRead()) {
+                    // check for a certificate needed to perform network A&A ops
+                    CheckCertificate checkCert = new CheckCertificate(AAI_PEM_FILE);
+                    checkCert.check();
+                } else {
+                    log.debug("AAI cert not found or unreadable");
+                }
             }
             
         } catch (CheckException ce) {


### PR DESCRIPTION
updated minoc, luskan, raven.
minoc and luskan were tolerant of a missing LocalAuthority, but not a missing cert.
raven did not handle either case.
tested locally removing one or both of the LocalAuthority.properties and the cadcproxy.pem.