### PR TITLE
Git issue: 614 - vault: copy and store additional Artifact props

### DIFF
--- a/cadc-inventory-db/build.gradle
+++ b/cadc-inventory-db/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 11
 
 group = 'org.opencadc'
 
-version = '1.1.0'
+version = '1.1.1'
 
 description = 'OpenCADC Storage Inventory database library'
 def git_url = 'https://github.com/opencadc/storage-inventory'

--- a/cadc-inventory-db/src/intTest/java/org/opencadc/vospace/db/DataNodeSizeWorkerTest.java
+++ b/cadc-inventory-db/src/intTest/java/org/opencadc/vospace/db/DataNodeSizeWorkerTest.java
@@ -84,7 +84,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.opencadc.inventory.Artifact;
-import org.opencadc.vospace.db.DataNodeSizeWorker;
+import org.opencadc.vospace.VOS;
 import org.opencadc.inventory.Namespace;
 import org.opencadc.inventory.StorageLocation;
 import org.opencadc.inventory.db.ArtifactDAO;
@@ -95,8 +95,6 @@ import org.opencadc.inventory.db.TestUtil;
 import org.opencadc.inventory.db.version.InitDatabaseSI;
 import org.opencadc.vospace.ContainerNode;
 import org.opencadc.vospace.DataNode;
-import org.opencadc.vospace.db.InitDatabaseVOS;
-import org.opencadc.vospace.db.NodeDAO;
 
 /**
  *
@@ -240,6 +238,14 @@ public class DataNodeSizeWorkerTest {
         Assert.assertNotNull(actual);
         log.info("found: "  + actual.getID() + " aka " + actual);
         Assert.assertEquals(expected.getContentLength(), actual.bytesUsed);
+        // verify the worker wrote new cached artifact props
+        String md5 = actual.getPropertyValue(VOS.PROPERTY_URI_CONTENTMD5);
+        Assert.assertNotNull("contentMD5 is not cached after first sync", md5);
+        Assert.assertEquals("false contentMD5 value", expected.getContentChecksum().getSchemeSpecificPart(), md5);
+        String contentDate = actual.getPropertyValue(VOS.PROPERTY_URI_CONTENTDATE);
+        // content-date is only stored when different from node.lastModified; just verify it is present or absent consistently
+        // (the artifact contentLastModified predates the node write, so it should differ)
+        Assert.assertNotNull("content-date cached after first sync", contentDate);
 
         Thread.sleep(100L);
         
@@ -263,13 +269,17 @@ public class DataNodeSizeWorkerTest {
 
         actual = (DataNode)nodeDAO.get(orig.getID());
         Assert.assertEquals(m1.getContentLength(), actual.bytesUsed);
+        // md5 unchanged (same checksum)
+        Assert.assertEquals("contentMD5 still correct after size update",
+                m1.getContentChecksum().getSchemeSpecificPart(),
+                actual.getPropertyValue(VOS.PROPERTY_URI_CONTENTMD5));
         final Date nodeLastMod = actual.getLastModified();
         
         Thread.sleep(100L);
         
         // replace the artifact but with the same contentLength to ensure timestamp change
         artifactDAO.delete(m1.getID());
-        Artifact m2 = new Artifact(expected.getURI(), expected.getContentChecksum(), new Date(), 333L); // same size
+        Artifact m2 = new Artifact(expected.getURI(), URI.create("md5:a7f3c91e5b8d4f20c6e1a9d73b2f4e8c"), new Date(), 333L); // same size
         if (isStorageSite) {
             m2.storageLocation = new StorageLocation(URI.create("id:" + UUID.randomUUID().toString()));
             m2.storageLocation.storageBucket = "X";
@@ -290,5 +300,9 @@ public class DataNodeSizeWorkerTest {
         actual = (DataNode)nodeDAO.get(orig.getID());
         Assert.assertEquals(m2.getContentLength(), actual.bytesUsed);
         Assert.assertTrue("timestamp change", actual.getLastModified().after(nodeLastMod));
+        // verify checksum was updated to m2's new value
+        Assert.assertEquals("contentMD5 did not update to new artifact checksum",
+                "a7f3c91e5b8d4f20c6e1a9d73b2f4e8c",
+                actual.getPropertyValue(VOS.PROPERTY_URI_CONTENTMD5));
     }
 }

--- a/cadc-inventory-db/src/main/java/org/opencadc/vospace/db/DataNodeSizeWorker.java
+++ b/cadc-inventory-db/src/main/java/org/opencadc/vospace/db/DataNodeSizeWorker.java
@@ -159,9 +159,9 @@ public class DataNodeSizeWorker implements Runnable {
                 if (node != null) {
                     NodeProperty contentChecksumProp = node.getProperty(VOS.PROPERTY_URI_CONTENTMD5);
                     boolean isMd5 = "md5".equalsIgnoreCase(artifact.getContentChecksum().getScheme());
-                    boolean updateContentChecksum = contentChecksumProp == null
-                            || !isMd5 // need to remove existing property if checksum is no longer MD5
-                            || !artifact.getContentChecksum().getSchemeSpecificPart().equals(contentChecksumProp.getValue());
+                    boolean updateContentChecksum = (contentChecksumProp == null && isMd5) // need to create new property for checksums
+                            || (contentChecksumProp != null // need to remove existing property if checksum is no longer MD5
+                                && (!isMd5 || !artifact.getContentChecksum().getSchemeSpecificPart().equals(contentChecksumProp.getValue())));
 
                     NodeProperty contentDateProp = node.getProperty(VOS.PROPERTY_URI_CONTENTDATE);
                     String contentLastModifiedStr = df.format(artifact.getContentLastModified());

--- a/cadc-inventory-db/src/main/java/org/opencadc/vospace/db/DataNodeSizeWorker.java
+++ b/cadc-inventory-db/src/main/java/org/opencadc/vospace/db/DataNodeSizeWorker.java
@@ -158,10 +158,10 @@ public class DataNodeSizeWorker implements Runnable {
                 DataNode node = nodeDAO.getDataNode(artifact.getURI());
                 if (node != null) {
                     NodeProperty contentChecksumProp = node.getProperty(VOS.PROPERTY_URI_CONTENTMD5);
+                    boolean isMd5 = "md5".equalsIgnoreCase(artifact.getContentChecksum().getScheme());
                     boolean updateContentChecksum = contentChecksumProp == null
-                            || !artifact.getContentChecksum().getScheme().equalsIgnoreCase("md5") // remove existing property if checksum is no longer MD5
-                            || (artifact.getContentChecksum().getScheme().equalsIgnoreCase("md5") // Persist VOSpace content-md5 property only for MD5 checksums
-                                    && !artifact.getContentChecksum().getSchemeSpecificPart().equals(contentChecksumProp.getValue()));
+                            || !isMd5 // need to remove existing property if checksum is no longer MD5
+                            || !artifact.getContentChecksum().getSchemeSpecificPart().equals(contentChecksumProp.getValue());
 
                     NodeProperty contentDateProp = node.getProperty(VOS.PROPERTY_URI_CONTENTDATE);
                     String contentLastModifiedStr = df.format(artifact.getContentLastModified());
@@ -189,7 +189,8 @@ public class DataNodeSizeWorker implements Runnable {
                             if (contentChecksumProp != null) {
                                 node.getProperties().remove(contentChecksumProp);
                             }
-                            if (artifact.getContentChecksum().getScheme().equalsIgnoreCase("md5")) {
+                            // Persist VOSpace content-md5 property only for MD5 checksums
+                            if (isMd5) {
                                 node.getProperties().add(new NodeProperty(VOS.PROPERTY_URI_CONTENTMD5, artifact.getContentChecksum().getSchemeSpecificPart()));
                             }
                         }

--- a/cadc-inventory-db/src/main/java/org/opencadc/vospace/db/DataNodeSizeWorker.java
+++ b/cadc-inventory-db/src/main/java/org/opencadc/vospace/db/DataNodeSizeWorker.java
@@ -158,8 +158,8 @@ public class DataNodeSizeWorker implements Runnable {
                 DataNode node = nodeDAO.getDataNode(artifact.getURI());
                 if (node != null) {
                     NodeProperty contentChecksumProp = node.getProperty(VOS.PROPERTY_URI_CONTENTMD5);
-                    boolean updateContentChecksum = contentChecksumProp == null ||
-                            (artifact.getContentChecksum().getScheme().equalsIgnoreCase("md5") // Persist VOSpace content-md5 property only for MD5 checksums
+                    boolean updateContentChecksum = contentChecksumProp == null
+                            || (artifact.getContentChecksum().getScheme().equalsIgnoreCase("md5") // Persist VOSpace content-md5 property only for MD5 checksums
                                     && !artifact.getContentChecksum().getSchemeSpecificPart().equals(contentChecksumProp.getValue()));
 
                     NodeProperty contentDateProp = node.getProperty(VOS.PROPERTY_URI_CONTENTDATE);

--- a/cadc-inventory-db/src/main/java/org/opencadc/vospace/db/DataNodeSizeWorker.java
+++ b/cadc-inventory-db/src/main/java/org/opencadc/vospace/db/DataNodeSizeWorker.java
@@ -168,11 +168,9 @@ public class DataNodeSizeWorker implements Runnable {
                         }
                         node.bytesUsed = artifact.getContentLength();
 
-                        // Persist #content-date only when it differs from the node #date value
-                        if (!node.getLastModified().equals(artifact.getContentLastModified())) {
-                            node.getProperties().removeIf(p -> VOS.PROPERTY_URI_CONTENTDATE.equals(p.getKey()));
-                            node.getProperties().add(new NodeProperty(VOS.PROPERTY_URI_CONTENTDATE, df.format(artifact.getContentLastModified())));
-                        }
+                        // update the #content-date in the props list
+                        node.getProperties().removeIf(p -> VOS.PROPERTY_URI_CONTENTDATE.equals(p.getKey()));
+                        node.getProperties().add(new NodeProperty(VOS.PROPERTY_URI_CONTENTDATE, df.format(artifact.getContentLastModified())));
 
                         // Persist VOSpace content-md5 property only for MD5 checksums
                         if (artifact.getContentChecksum().getScheme().equalsIgnoreCase("md5")) {

--- a/cadc-inventory-db/src/main/java/org/opencadc/vospace/db/DataNodeSizeWorker.java
+++ b/cadc-inventory-db/src/main/java/org/opencadc/vospace/db/DataNodeSizeWorker.java
@@ -157,8 +157,17 @@ public class DataNodeSizeWorker implements Runnable {
                 Artifact artifact = iter.next();
                 DataNode node = nodeDAO.getDataNode(artifact.getURI());
                 if (node != null) {
-                    boolean delta = !artifact.getContentLength().equals(node.bytesUsed); // size change
-                    delta = delta || artifact.getLastModified().after(node.getLastModified());
+                    NodeProperty contentChecksumProp = node.getProperty(VOS.PROPERTY_URI_CONTENTMD5);
+                    boolean updateContentChecksum = contentChecksumProp == null ||
+                            (artifact.getContentChecksum().getScheme().equalsIgnoreCase("md5") // Persist VOSpace content-md5 property only for MD5 checksums
+                                    && !artifact.getContentChecksum().getSchemeSpecificPart().equals(contentChecksumProp.getValue()));
+
+                    NodeProperty contentDateProp = node.getProperty(VOS.PROPERTY_URI_CONTENTDATE);
+                    boolean updateContentDate = contentDateProp == null || !df.format(artifact.getContentLastModified()).equals(contentDateProp.getValue());
+
+                    boolean updateBytesUsed = !artifact.getContentLength().equals(node.bytesUsed);
+
+                    boolean delta = updateBytesUsed || updateContentChecksum || updateContentDate;
                     log.debug(artifact.getURI() + " len=" + artifact.getContentLength() + " -> " + node.getName());
                     tm.startTransaction();
                     try {
@@ -168,13 +177,16 @@ public class DataNodeSizeWorker implements Runnable {
                         }
                         node.bytesUsed = artifact.getContentLength();
 
-                        // update the #content-date in the props list
-                        node.getProperties().removeIf(p -> VOS.PROPERTY_URI_CONTENTDATE.equals(p.getKey()));
-                        node.getProperties().add(new NodeProperty(VOS.PROPERTY_URI_CONTENTDATE, df.format(artifact.getContentLastModified())));
-
-                        // Persist VOSpace content-md5 property only for MD5 checksums
-                        if (artifact.getContentChecksum().getScheme().equalsIgnoreCase("md5")) {
-                            node.getProperties().removeIf(p -> VOS.PROPERTY_URI_CONTENTMD5.equals(p.getKey()));
+                        if (updateContentDate) {
+                            if (contentDateProp != null) {
+                                node.getProperties().remove(contentDateProp);
+                            }
+                            node.getProperties().add(new NodeProperty(VOS.PROPERTY_URI_CONTENTDATE, df.format(artifact.getContentLastModified())));
+                        }
+                        if (updateContentChecksum) {
+                            if (contentChecksumProp != null) {
+                                node.getProperties().remove(contentChecksumProp);
+                            }
                             node.getProperties().add(new NodeProperty(VOS.PROPERTY_URI_CONTENTMD5, artifact.getContentChecksum().getSchemeSpecificPart()));
                         }
 

--- a/cadc-inventory-db/src/main/java/org/opencadc/vospace/db/DataNodeSizeWorker.java
+++ b/cadc-inventory-db/src/main/java/org/opencadc/vospace/db/DataNodeSizeWorker.java
@@ -159,11 +159,13 @@ public class DataNodeSizeWorker implements Runnable {
                 if (node != null) {
                     NodeProperty contentChecksumProp = node.getProperty(VOS.PROPERTY_URI_CONTENTMD5);
                     boolean updateContentChecksum = contentChecksumProp == null
+                            || !artifact.getContentChecksum().getScheme().equalsIgnoreCase("md5") // remove existing property if checksum is no longer MD5
                             || (artifact.getContentChecksum().getScheme().equalsIgnoreCase("md5") // Persist VOSpace content-md5 property only for MD5 checksums
                                     && !artifact.getContentChecksum().getSchemeSpecificPart().equals(contentChecksumProp.getValue()));
 
                     NodeProperty contentDateProp = node.getProperty(VOS.PROPERTY_URI_CONTENTDATE);
-                    boolean updateContentDate = contentDateProp == null || !df.format(artifact.getContentLastModified()).equals(contentDateProp.getValue());
+                    String contentLastModifiedStr = df.format(artifact.getContentLastModified());
+                    boolean updateContentDate = contentDateProp == null || !contentLastModifiedStr.equals(contentDateProp.getValue());
 
                     boolean updateBytesUsed = !artifact.getContentLength().equals(node.bytesUsed);
 
@@ -181,13 +183,15 @@ public class DataNodeSizeWorker implements Runnable {
                             if (contentDateProp != null) {
                                 node.getProperties().remove(contentDateProp);
                             }
-                            node.getProperties().add(new NodeProperty(VOS.PROPERTY_URI_CONTENTDATE, df.format(artifact.getContentLastModified())));
+                            node.getProperties().add(new NodeProperty(VOS.PROPERTY_URI_CONTENTDATE, contentLastModifiedStr));
                         }
                         if (updateContentChecksum) {
                             if (contentChecksumProp != null) {
                                 node.getProperties().remove(contentChecksumProp);
                             }
-                            node.getProperties().add(new NodeProperty(VOS.PROPERTY_URI_CONTENTMD5, artifact.getContentChecksum().getSchemeSpecificPart()));
+                            if (artifact.getContentChecksum().getScheme().equalsIgnoreCase("md5")) {
+                                node.getProperties().add(new NodeProperty(VOS.PROPERTY_URI_CONTENTMD5, artifact.getContentChecksum().getSchemeSpecificPart()));
+                            }
                         }
 
                         nodeDAO.put(node, delta); // delta forces lastModified update

--- a/cadc-inventory-db/src/main/java/org/opencadc/vospace/db/DataNodeSizeWorker.java
+++ b/cadc-inventory-db/src/main/java/org/opencadc/vospace/db/DataNodeSizeWorker.java
@@ -80,6 +80,8 @@ import org.opencadc.inventory.db.ArtifactDAO;
 import org.opencadc.inventory.db.HarvestState;
 import org.opencadc.inventory.db.HarvestStateDAO;
 import org.opencadc.vospace.DataNode;
+import org.opencadc.vospace.NodeProperty;
+import org.opencadc.vospace.VOS;
 
 /**
  * This class performs the work of synchronizing the size of Data Nodes from 
@@ -165,6 +167,19 @@ public class DataNodeSizeWorker implements Runnable {
                             continue; // node gone - race condition
                         }
                         node.bytesUsed = artifact.getContentLength();
+
+                        // Persist #content-date only when it differs from the node #date value
+                        if (!node.getLastModified().equals(artifact.getContentLastModified())) {
+                            node.getProperties().removeIf(p -> VOS.PROPERTY_URI_CONTENTDATE.equals(p.getKey()));
+                            node.getProperties().add(new NodeProperty(VOS.PROPERTY_URI_CONTENTDATE, df.format(artifact.getContentLastModified())));
+                        }
+
+                        // Persist VOSpace content-md5 property only for MD5 checksums
+                        if (artifact.getContentChecksum().getScheme().equalsIgnoreCase("md5")) {
+                            node.getProperties().removeIf(p -> VOS.PROPERTY_URI_CONTENTMD5.equals(p.getKey()));
+                            node.getProperties().add(new NodeProperty(VOS.PROPERTY_URI_CONTENTMD5, artifact.getContentChecksum().getSchemeSpecificPart()));
+                        }
+
                         nodeDAO.put(node, delta); // delta forces lastModified update
                         tm.commitTransaction();
                         log.debug("ArtifactSyncWorker.updateDataNode id=" + node.getID() 

--- a/vault/VERSION
+++ b/vault/VERSION
@@ -4,6 +4,6 @@
 # tags with and without build number so operators use the versioned
 # tag but we always keep a timestamped tag in case a semantic tag gets
 # replaced accidentally
-VER=1.1.1
+VER=1.1.2
 TAGS="${VER} ${VER}-$(date -u +"%Y%m%dT%H%M%S")"
 unset VER

--- a/vault/src/intTest/java/org/opencadc/vault/NodesTest.java
+++ b/vault/src/intTest/java/org/opencadc/vault/NodesTest.java
@@ -67,13 +67,40 @@
 
 package org.opencadc.vault;
 
-import ca.nrc.cadc.util.FileUtil;
+import ca.nrc.cadc.auth.RunnableAction;
+import ca.nrc.cadc.net.FileContent;
+import ca.nrc.cadc.net.HttpGet;
+import ca.nrc.cadc.net.HttpPost;
+import ca.nrc.cadc.net.HttpUpload;
+import ca.nrc.cadc.reg.Standards;
+import ca.nrc.cadc.util.HexUtil;
 import ca.nrc.cadc.util.Log4jInit;
-import java.io.File;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URL;
+import java.security.MessageDigest;
+import java.util.Random;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
+import org.junit.Assert;
+import org.junit.Test;
+import org.opencadc.conformance.vos.VOSTest;
 import org.opencadc.gms.GroupURI;
+import org.opencadc.vospace.DataNode;
+import org.opencadc.vospace.NodeProperty;
+import org.opencadc.vospace.VOS;
+import org.opencadc.vospace.VOSURI;
+import org.opencadc.vospace.io.NodeReader;
+import org.opencadc.vospace.transfer.Direction;
+import org.opencadc.vospace.transfer.Protocol;
+import org.opencadc.vospace.transfer.Transfer;
+import org.opencadc.vospace.transfer.TransferParsingException;
+import org.opencadc.vospace.transfer.TransferReader;
+import org.opencadc.vospace.transfer.TransferWriter;
+import javax.security.auth.Subject;
 
 /**
  * Test the nodes endpoint.
@@ -96,4 +123,142 @@ public class NodesTest extends org.opencadc.conformance.vos.NodesTest {
         // vault does not check the actual groups in the permission props tests, hence they can be made up.
         enablePermissionPropsTest(new GroupURI(URI.create("ivo://myauth/gms?gr1")), new GroupURI(URI.create("ivo://myauth/gms?gr2")));
     }
+
+    @Test
+    public void testDataNodeProps() {
+        try {
+            // create a simple data node
+            String name = "testDataNode";
+            URL nodeURL = getNodeURL(nodesServiceURL, name);
+            VOSURI nodeURI = getVOSURI(name);
+
+            // cleanup
+            delete(nodeURL, false);
+
+            // PUT the node
+            log.info("put: " + nodeURI + " -> " + nodeURL);
+            DataNode testNode = new DataNode(name);
+            put(nodeURL, nodeURI, testNode);
+
+            // GET the new node
+            NodeReader.NodeReaderResult result = get(nodeURL, 200, XML_CONTENT_TYPE);
+            log.info("found: " + result.vosURI + " owner: " + result.node.ownerDisplay);
+            Assert.assertTrue(result.node instanceof DataNode);
+            DataNode persistedNode = (DataNode) result.node;
+            for (NodeProperty np : persistedNode.getProperties()) {
+                log.info("persisted prop: " + np.getKey() + " = " + np.getValue());
+            }
+            Assert.assertEquals(testNode, persistedNode);
+            Assert.assertEquals(nodeURI, result.vosURI);
+            Assert.assertNull(persistedNode.getProperty(VOS.PROPERTY_URI_CONTENTMD5));
+            Assert.assertNull(persistedNode.getProperty(VOS.PROPERTY_URI_CONTENTDATE));
+
+            // Push some data to the node
+            PushData(nodeURI.getURI());
+
+            result = get(nodeURL, 200, XML_CONTENT_TYPE);
+            log.info("found: " + result.vosURI + " owner: " + result.node.ownerDisplay);
+            Assert.assertTrue(result.node instanceof DataNode);
+            persistedNode = (DataNode) result.node;
+            Assert.assertNotNull(persistedNode.getProperties());
+            for (NodeProperty np : persistedNode.getProperties()) {
+                log.info("persisted prop: " + np.getKey() + " = " + np.getValue());
+            }
+            Assert.assertEquals(testNode, persistedNode);
+            Assert.assertEquals(nodeURI, result.vosURI);
+            Assert.assertNotNull(persistedNode.getProperty(VOS.PROPERTY_URI_CONTENTMD5));
+            Assert.assertNotNull(persistedNode.getProperty(VOS.PROPERTY_URI_CONTENTDATE));
+
+            if (cleanupOnSuccess) {
+                delete(nodeURL);
+            }
+        } catch (Exception e) {
+            log.error("Unexpected error", e);
+            Assert.fail("Unexpected error: " + e);
+        }
+    }
+
+    private void PushData(URI testURI) throws Exception {
+        // Create a push-to-vospace Transfer for the node
+        Transfer pushTransfer = new Transfer(testURI, Direction.pushToVoSpace);
+        pushTransfer.version = VOS.VOSPACE_21;
+        pushTransfer.getProtocols().add(new Protocol(VOS.PROTOCOL_HTTPS_PUT)); // anon, preauth
+        Protocol putWithCert = new Protocol(VOS.PROTOCOL_HTTPS_PUT);
+        putWithCert.setSecurityMethod(Standards.SECURITY_METHOD_CERT);
+        pushTransfer.getProtocols().add(putWithCert);
+
+        // negotiate the transfer
+        Transfer details = doTransfer(pushTransfer);
+        Assert.assertEquals("expected transfer direction = " + Direction.pushToVoSpace,
+                Direction.pushToVoSpace, details.getDirection());
+        Assert.assertNotNull(details.getProtocols());
+        log.info(pushTransfer.getDirection() + " results: " + details.getProtocols().size());
+        URL putURL = null;
+        for (Protocol p : details.getProtocols()) {
+            String endpoint = p.getEndpoint();
+            try {
+
+                URL u = new URL(endpoint);
+                if (putURL == null) {
+                    putURL = u; // first
+                }
+            } catch (MalformedURLException e) {
+                Assert.fail(String.format("invalid protocol endpoint: %s because %s", endpoint, e.getMessage()));
+            }
+        }
+        Assert.assertNotNull(putURL);
+
+        // put the bytes
+        Random rnd = new Random();
+        byte[] data = new byte[1024];
+        rnd.nextBytes(data);
+        MessageDigest md5 = MessageDigest.getInstance("MD5");
+        md5.update(data);
+
+        // put data
+        md5.reset();
+        md5.update(data);
+        URI digestURI = URI.create("md5:" + HexUtil.toHex(md5.digest()));
+        FileContent content = new FileContent(data, "application/octet-stream");
+        HttpUpload put = new HttpUpload(content, putURL);
+        put.setDigest(digestURI);
+        put.run();
+        log.info("put accept: " + put.getResponseCode() + " " + put.getThrowable() + " " + put.getDigest());
+        Assert.assertEquals(201, put.getResponseCode());
+        Assert.assertNull(put.getThrowable());
+        Assert.assertEquals(digestURI, put.getDigest());
+
+    }
+
+    protected Transfer doTransfer(Transfer transfer) throws IOException, TransferParsingException {
+        // Write a transfer document
+        TransferWriter transferWriter = new TransferWriter();
+        StringWriter sw = new StringWriter();
+        transferWriter.write(transfer, sw);
+        log.debug("POST Transfer XML: " + sw);
+
+        // POST the transfer document
+        FileContent fileContent = new FileContent(sw.toString().getBytes(), VOSTest.XML_CONTENT_TYPE);
+        HttpPost post = new HttpPost(synctransServiceURL, fileContent, false);
+        Subject.doAs(authSubject, new RunnableAction(post));
+        Assert.assertEquals("expected POST response code = 303",303, post.getResponseCode());
+        Assert.assertNull("expected POST throwable == null", post.getThrowable());
+
+        // Get the updated transfer
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        HttpGet get = new HttpGet(post.getRedirectURL(), out);
+        log.debug("GET: " + post.getRedirectURL());
+        Subject.doAs(authSubject, new RunnableAction(get));
+        log.debug("GET responseCode: " + get.getResponseCode());
+        Assert.assertEquals("expected GET response code = 200", 200, get.getResponseCode());
+        Assert.assertNull("expected GET throwable == null", get.getThrowable());
+        Assert.assertTrue("expected GET Content-Type starts with " + VOSTest.XML_CONTENT_TYPE,
+                get.getContentType().startsWith(VOSTest.XML_CONTENT_TYPE));
+
+        // Read the transfer
+        log.debug("GET Transfer XML: " + out);
+        TransferReader transferReader = new TransferReader();
+        return transferReader.read(out.toString(), "vos");
+    }
+
 }

--- a/vault/src/main/java/org/opencadc/vault/NodePersistenceImpl.java
+++ b/vault/src/main/java/org/opencadc/vault/NodePersistenceImpl.java
@@ -417,11 +417,9 @@ public class NodePersistenceImpl implements NodePersistence {
                             dn = locked; // safer than accidentally using the wrong variable
                             dn.bytesUsed = a.getContentLength();
 
-                            // Persist #content-date only when it differs from the node #date value
-                            if (!ret.getLastModified().equals(a.getContentLastModified())) {
-                                dn.getProperties().removeIf(p -> VOS.PROPERTY_URI_CONTENTDATE.equals(p.getKey()));
-                                dn.getProperties().add(new NodeProperty(VOS.PROPERTY_URI_CONTENTDATE, df.format(a.getContentLastModified())));
-                            }
+                            // update the #content-date in the props list
+                            dn.getProperties().removeIf(p -> VOS.PROPERTY_URI_CONTENTDATE.equals(p.getKey()));
+                            dn.getProperties().add(new NodeProperty(VOS.PROPERTY_URI_CONTENTDATE, df.format(a.getContentLastModified())));
 
                             // Persist VOSpace content-md5 property only for MD5 checksums
                             if (a.getContentChecksum().getScheme().equalsIgnoreCase("md5")) {

--- a/vault/src/main/java/org/opencadc/vault/NodePersistenceImpl.java
+++ b/vault/src/main/java/org/opencadc/vault/NodePersistenceImpl.java
@@ -405,11 +405,13 @@ public class NodePersistenceImpl implements NodePersistence {
                 // be consistent with DataNodeSizeWorker
                 NodeProperty contentChecksumProp = dn.getProperty(VOS.PROPERTY_URI_CONTENTMD5);
                 boolean updateContentChecksum = contentChecksumProp == null
+                        || !a.getContentChecksum().getScheme().equalsIgnoreCase("md5") // remove existing property if checksum is no longer MD5
                         || (a.getContentChecksum().getScheme().equalsIgnoreCase("md5") // Persist VOSpace content-md5 property only for MD5 checksums
                                 && !a.getContentChecksum().getSchemeSpecificPart().equals(contentChecksumProp.getValue()));
 
                 NodeProperty contentDateProp = dn.getProperty(VOS.PROPERTY_URI_CONTENTDATE);
-                boolean updateContentDate = contentDateProp == null || !df.format(a.getContentLastModified()).equals(contentDateProp.getValue());
+                String contentLastModifiedStr = df.format(a.getContentLastModified());
+                boolean updateContentDate = contentDateProp == null || !contentLastModifiedStr.equals(contentDateProp.getValue());
 
                 boolean updateBytesUsed = !a.getContentLength().equals(dn.bytesUsed);
 
@@ -430,13 +432,15 @@ public class NodePersistenceImpl implements NodePersistence {
                                 if (contentDateProp != null) {
                                     dn.getProperties().remove(contentDateProp);
                                 }
-                                dn.getProperties().add(new NodeProperty(VOS.PROPERTY_URI_CONTENTDATE, df.format(a.getContentLastModified())));
+                                dn.getProperties().add(new NodeProperty(VOS.PROPERTY_URI_CONTENTDATE, contentLastModifiedStr));
                             }
                             if (updateContentChecksum) {
                                 if (contentChecksumProp != null) {
                                     dn.getProperties().remove(contentChecksumProp);
                                 }
-                                dn.getProperties().add(new NodeProperty(VOS.PROPERTY_URI_CONTENTMD5, a.getContentChecksum().getSchemeSpecificPart()));
+                                if (a.getContentChecksum().getScheme().equalsIgnoreCase("md5")) {
+                                    dn.getProperties().add(new NodeProperty(VOS.PROPERTY_URI_CONTENTMD5, a.getContentChecksum().getSchemeSpecificPart()));
+                                }
                             }
 
                             dao.put(dn, delta);

--- a/vault/src/main/java/org/opencadc/vault/NodePersistenceImpl.java
+++ b/vault/src/main/java/org/opencadc/vault/NodePersistenceImpl.java
@@ -405,9 +405,9 @@ public class NodePersistenceImpl implements NodePersistence {
                 // be consistent with DataNodeSizeWorker
                 NodeProperty contentChecksumProp = dn.getProperty(VOS.PROPERTY_URI_CONTENTMD5);
                 boolean isMd5 = "md5".equalsIgnoreCase(a.getContentChecksum().getScheme());
-                boolean updateContentChecksum = contentChecksumProp == null
-                        || !isMd5 // need to remove existing property if checksum is no longer MD5
-                        || !a.getContentChecksum().getSchemeSpecificPart().equals(contentChecksumProp.getValue());
+                boolean updateContentChecksum = (contentChecksumProp == null && isMd5) // need to create new property for checksums
+                        || (contentChecksumProp != null // need to remove existing property if checksum is no longer MD5
+                            && (!isMd5 || !a.getContentChecksum().getSchemeSpecificPart().equals(contentChecksumProp.getValue())));
 
                 NodeProperty contentDateProp = dn.getProperty(VOS.PROPERTY_URI_CONTENTDATE);
                 String contentLastModifiedStr = df.format(a.getContentLastModified());

--- a/vault/src/main/java/org/opencadc/vault/NodePersistenceImpl.java
+++ b/vault/src/main/java/org/opencadc/vault/NodePersistenceImpl.java
@@ -404,8 +404,8 @@ public class NodePersistenceImpl implements NodePersistence {
                 
                 // be consistent with DataNodeSizeWorker
                 NodeProperty contentChecksumProp = dn.getProperty(VOS.PROPERTY_URI_CONTENTMD5);
-                boolean updateContentChecksum = contentChecksumProp == null ||
-                        (a.getContentChecksum().getScheme().equalsIgnoreCase("md5") // Persist VOSpace content-md5 property only for MD5 checksums
+                boolean updateContentChecksum = contentChecksumProp == null
+                        || (a.getContentChecksum().getScheme().equalsIgnoreCase("md5") // Persist VOSpace content-md5 property only for MD5 checksums
                                 && !a.getContentChecksum().getSchemeSpecificPart().equals(contentChecksumProp.getValue()));
 
                 NodeProperty contentDateProp = dn.getProperty(VOS.PROPERTY_URI_CONTENTDATE);

--- a/vault/src/main/java/org/opencadc/vault/NodePersistenceImpl.java
+++ b/vault/src/main/java/org/opencadc/vault/NodePersistenceImpl.java
@@ -403,8 +403,17 @@ public class NodePersistenceImpl implements NodePersistence {
                 // and may help hide some inconsistencies in child listing sizes
                 
                 // be consistent with DataNodeSizeWorker
-                boolean delta = !a.getContentLength().equals(dn.bytesUsed); // size change
-                delta = delta || a.getLastModified().after(dn.getLastModified());
+                NodeProperty contentChecksumProp = dn.getProperty(VOS.PROPERTY_URI_CONTENTMD5);
+                boolean updateContentChecksum = contentChecksumProp == null ||
+                        (a.getContentChecksum().getScheme().equalsIgnoreCase("md5") // Persist VOSpace content-md5 property only for MD5 checksums
+                                && !a.getContentChecksum().getSchemeSpecificPart().equals(contentChecksumProp.getValue()));
+
+                NodeProperty contentDateProp = dn.getProperty(VOS.PROPERTY_URI_CONTENTDATE);
+                boolean updateContentDate = contentDateProp == null || !df.format(a.getContentLastModified()).equals(contentDateProp.getValue());
+
+                boolean updateBytesUsed = !a.getContentLength().equals(dn.bytesUsed);
+
+                boolean delta = updateBytesUsed || updateContentChecksum || updateContentDate;
                 if (delta) {
                     TransactionManager txn = dao.getTransactionManager();
                     try {
@@ -417,13 +426,16 @@ public class NodePersistenceImpl implements NodePersistence {
                             dn = locked; // safer than accidentally using the wrong variable
                             dn.bytesUsed = a.getContentLength();
 
-                            // update the #content-date in the props list
-                            dn.getProperties().removeIf(p -> VOS.PROPERTY_URI_CONTENTDATE.equals(p.getKey()));
-                            dn.getProperties().add(new NodeProperty(VOS.PROPERTY_URI_CONTENTDATE, df.format(a.getContentLastModified())));
-
-                            // Persist VOSpace content-md5 property only for MD5 checksums
-                            if (a.getContentChecksum().getScheme().equalsIgnoreCase("md5")) {
-                                dn.getProperties().removeIf(p -> VOS.PROPERTY_URI_CONTENTMD5.equals(p.getKey()));
+                            if (updateContentDate) {
+                                if (contentDateProp != null) {
+                                    dn.getProperties().remove(contentDateProp);
+                                }
+                                dn.getProperties().add(new NodeProperty(VOS.PROPERTY_URI_CONTENTDATE, df.format(a.getContentLastModified())));
+                            }
+                            if (updateContentChecksum) {
+                                if (contentChecksumProp != null) {
+                                    dn.getProperties().remove(contentChecksumProp);
+                                }
                                 dn.getProperties().add(new NodeProperty(VOS.PROPERTY_URI_CONTENTMD5, a.getContentChecksum().getSchemeSpecificPart()));
                             }
 

--- a/vault/src/main/java/org/opencadc/vault/NodePersistenceImpl.java
+++ b/vault/src/main/java/org/opencadc/vault/NodePersistenceImpl.java
@@ -416,6 +416,19 @@ public class NodePersistenceImpl implements NodePersistence {
                         if (locked != null) {
                             dn = locked; // safer than accidentally using the wrong variable
                             dn.bytesUsed = a.getContentLength();
+
+                            // Persist #content-date only when it differs from the node #date value
+                            if (!ret.getLastModified().equals(a.getContentLastModified())) {
+                                dn.getProperties().removeIf(p -> VOS.PROPERTY_URI_CONTENTDATE.equals(p.getKey()));
+                                dn.getProperties().add(new NodeProperty(VOS.PROPERTY_URI_CONTENTDATE, df.format(a.getContentLastModified())));
+                            }
+
+                            // Persist VOSpace content-md5 property only for MD5 checksums
+                            if (a.getContentChecksum().getScheme().equalsIgnoreCase("md5")) {
+                                dn.getProperties().removeIf(p -> VOS.PROPERTY_URI_CONTENTMD5.equals(p.getKey()));
+                                dn.getProperties().add(new NodeProperty(VOS.PROPERTY_URI_CONTENTMD5, a.getContentChecksum().getSchemeSpecificPart()));
+                            }
+
                             dao.put(dn, delta);
                             ret = dn;
                         }
@@ -446,16 +459,6 @@ public class NodePersistenceImpl implements NodePersistence {
                 //       cause a visible #date change; probably OK
                 ret.getProperties().add(new NodeProperty(VOS.PROPERTY_URI_DATE, df.format(ret.getLastModified())));
 
-                // #content-date is only output if different from #date
-                if (!ret.getLastModified().equals(a.getContentLastModified())) {
-                    ret.getProperties().add(new NodeProperty(VOS.PROPERTY_URI_CONTENTDATE, df.format(a.getContentLastModified())));
-                }
-
-                // only #md5 in VOSpace spec
-                if (a.getContentChecksum().getScheme().equalsIgnoreCase("md5")) {
-                    ret.getProperties().add(new NodeProperty(VOS.PROPERTY_URI_CONTENTMD5, a.getContentChecksum().getSchemeSpecificPart()));
-                }
-                
                 if (a.contentEncoding != null) {
                     ret.getProperties().add(new NodeProperty(VOS.PROPERTY_URI_CONTENTENCODING, a.contentEncoding));
                 }

--- a/vault/src/main/java/org/opencadc/vault/NodePersistenceImpl.java
+++ b/vault/src/main/java/org/opencadc/vault/NodePersistenceImpl.java
@@ -404,10 +404,10 @@ public class NodePersistenceImpl implements NodePersistence {
                 
                 // be consistent with DataNodeSizeWorker
                 NodeProperty contentChecksumProp = dn.getProperty(VOS.PROPERTY_URI_CONTENTMD5);
+                boolean isMd5 = "md5".equalsIgnoreCase(a.getContentChecksum().getScheme());
                 boolean updateContentChecksum = contentChecksumProp == null
-                        || !a.getContentChecksum().getScheme().equalsIgnoreCase("md5") // remove existing property if checksum is no longer MD5
-                        || (a.getContentChecksum().getScheme().equalsIgnoreCase("md5") // Persist VOSpace content-md5 property only for MD5 checksums
-                                && !a.getContentChecksum().getSchemeSpecificPart().equals(contentChecksumProp.getValue()));
+                        || !isMd5 // need to remove existing property if checksum is no longer MD5
+                        || !a.getContentChecksum().getSchemeSpecificPart().equals(contentChecksumProp.getValue());
 
                 NodeProperty contentDateProp = dn.getProperty(VOS.PROPERTY_URI_CONTENTDATE);
                 String contentLastModifiedStr = df.format(a.getContentLastModified());
@@ -438,7 +438,8 @@ public class NodePersistenceImpl implements NodePersistence {
                                 if (contentChecksumProp != null) {
                                     dn.getProperties().remove(contentChecksumProp);
                                 }
-                                if (a.getContentChecksum().getScheme().equalsIgnoreCase("md5")) {
+                                // Persist VOSpace content-md5 property only for MD5 checksums
+                                if (isMd5) {
                                     dn.getProperties().add(new NodeProperty(VOS.PROPERTY_URI_CONTENTMD5, a.getContentChecksum().getSchemeSpecificPart()));
                                 }
                             }


### PR DESCRIPTION
- Persist VOSpace content metadata properties (#content-date and #content-md5) to DataNode properties
  - Instead of adding them only to the GET response object
  - During the Data Node size sync process
- Update DataNodeSizeWorkerTest.java to validate persisted metadata changes
- Add a test to the NodesTest.java to validate the GET action with persisted content metadata properties